### PR TITLE
Update SDL2 binaries to 2.0.16

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,7 @@ task:
   name: "Build $SDL2DLL_PLATFORM (i686) wheel"
 
   env:
-    SDL2DLL_PLATFORM: manylinux2010
+    SDL2DLL_PLATFORM: manylinux2014
 
   container:
     image: quay.io/pypa/$SDL2DLL_PLATFORM_i686
@@ -64,7 +64,7 @@ task:
 
   env:
     matrix:
-      - SDL2DLL_PLATFORM: manylinux2010
+      - SDL2DLL_PLATFORM: manylinux2014
       - SDL2DLL_PLATFORM: manylinux_2_24
   
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,7 +69,7 @@ task:
   
   container:
     image: quay.io/pypa/$SDL2DLL_PLATFORM_x86_64
-    memory: 1G
+    memory: 2G
 
   script:
     - ./manylinux.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed `RuntimeWarning` when importing with Microsoft Store Python, which is properly supported as of PySDL2 0.9.8.
 - Increased the target for the "legacy" manylinux wheels from `manylinux2010` to `manylinux2014`, due to an incompatibility with SDL2 2.0.16's use of the `dbus` library and the very old `dbus` version included in the official `manylinux2010` images.
 - Removed dynamic support for the ancient Network Audio System (libaudio) backend in the "legacy" manylinux wheels, due to the package not being available for 32-bit `manylinux2014` images.
+- Added experimental dynamic support for Pipewire audio (>= 0.3) in the "modern" manylinux wheels.
 
 ### Version 2.0.14.post2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pysdl2-dll changelog
 
+### Version 2.0.16
+
+- Bumped the SDL2 binary version from 2.0.14 to 2.0.16.
+- Removed `RuntimeWarning` when importing with Microsoft Store Python, which is properly supported as of PySDL2 0.9.8.
+- Increased the target for the "legacy" manylinux wheels from `manylinux2010` to `manylinux2014`, due to an incompatibility with SDL2 2.0.16's use of the `dbus` library and the very old `dbus` version included in the official `manylinux2010` images.
+- Removed dynamic support for the ancient Network Audio System (libaudio) backend in the "legacy" manylinux wheels, due to the package not being available for 32-bit `manylinux2014` images.
+
 ### Version 2.0.14.post2
 
 - Added support for Linux (x86, 32-bit and 64-bit), using the official `manylinux` images to build SDL2 and its companion libraries from source.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It uses the official SDL2, SDL2\_mixer, SDL2\_ttf, and SDL2\_image binaries for 
 
 The latest release includes the following versions of the SDL2 binaries:
 
-SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2_gfx
+SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
 2.0.16 | 2.0.15 | 2.0.4 | 2.0.5 | 1.0.4
 
@@ -27,9 +27,9 @@ pip install pysdl2-dll # install latest release version
 
 At present, the following platforms are supported:
 
-* macOS (10.6+, 64-bit)
-* Windows (32-bit)
-* Windows (64-bit)
+* macOS (10.6+, 64-bit x86)
+* Windows (32-bit x86)
+* Windows (64-bit x86)
 * Linux (32-bit x86)
 * Linux (64-bit x86)
 
@@ -45,7 +45,7 @@ Because the wheels are not built against any specfic version of Python, pysdl2-d
 
 ### Linux Requirements
 
-There are currently two versions the Linux wheels: one based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and another based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
+There are currently two versions the Linux wheels: "legacy" wheels based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and "modern" wheels based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
 
 You must have pip 19.3 or newer to install the `manylinux_2014` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Because the wheels are not built against any specfic version of Python, pysdl2-d
 
 ### Linux Requirements
 
-There are currently two versions the Linux wheels: "legacy" wheels based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and "modern" wheels based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
+There are currently two versions the Linux wheels: "legacy" wheels based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and "modern" wheels based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, Pipewire/sndio/JACK audio, and OpenGL ES v1 rendering.
 
 You must have pip 19.3 or newer to install the `manylinux_2014` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ pysdl2-dll requires PySDL2 0.9.7 or later in order to work correctly on macOS, a
 pip install -U pysdl2
 ```
 
+Because the wheels are not built against any specfic version of Python, pysdl2-dll supports all versions and implementations of Python that are supported by PySDL2.
+
 ### Linux Requirements
 
-There are currently two versions the Linux wheels: one based on the `manylinux2010` standard (for 32-bit and 64-bit x86), and another based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
+There are currently two versions the Linux wheels: one based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and another based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
 
-You must have pip 19.0 or newer to install the `manylinux_2010` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
+You must have pip 19.3 or newer to install the `manylinux_2014` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
 
 ## Usage
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,7 +15,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.0.14',
+    'SDL2': '2.0.16',
     'SDL2_mixer': '2.0.4',
     'SDL2_ttf': '2.0.15',
     'SDL2_image': '2.0.5',

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -4,7 +4,7 @@ set -e -u -x
 
 # Initialize the PATH and initial directory
 
-export PATH=$PATH:/opt/python/cp37-cp37m/bin
+export PATH=/opt/python/cp37-cp37m/bin:$PATH
 
 if [ -d "/io" ]; then
     cd /io
@@ -38,7 +38,7 @@ else
 
     # Install Pipewire from source (done before other audio backends to minimize build time)
     export PIPEWIRE_VERSION=0.3.33
-    export PIPEWIRE_URL=https://gitlab.freedesktop.org/pipewire/-/archive
+    export PIPEWIRE_URL=https://gitlab.freedesktop.org/pipewire/pipewire/-/archive
     python -m pip install meson ninja
     curl $PIPEWIRE_URL/$PIPEWIRE_VERSION/pipewire-$PIPEWIRE_VERSION.tar.gz | tar -xz
     cd pipewire-$PIPEWIRE_VERSION

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -4,7 +4,7 @@ set -e -u -x
 
 # Initialize the PATH and initial directory
 
-#export PATH=/opt/python/cp37-cp37m/bin:$PATH
+export PATH=/opt/python/cp37-cp37m/bin:$PATH
 
 if [ -d "/io" ]; then
     cd /io
@@ -39,8 +39,7 @@ else
     # Install Pipewire from source (done before other audio backends to minimize build time)
     export PIPEWIRE_VERSION=0.3.33
     export PIPEWIRE_URL=https://gitlab.freedesktop.org/pipewire/pipewire/-/archive
-    /opt/python/cp37-cp37m/bin/python -m pip install meson ninja
-    export PATH=$PATH:/opt/python/cp37-cp37m/bin
+    python3.7 -m pip install meson ninja
     curl $PIPEWIRE_URL/$PIPEWIRE_VERSION/pipewire-$PIPEWIRE_VERSION.tar.gz | tar -xz
     cd pipewire-$PIPEWIRE_VERSION
     ./autogen.sh --prefix=/usr

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -4,7 +4,7 @@ set -e -u -x
 
 # Initialize the PATH and initial directory
 
-export PATH=/opt/python/cp37-cp37m/bin:$PATH
+#export PATH=/opt/python/cp37-cp37m/bin:$PATH
 
 if [ -d "/io" ]; then
     cd /io
@@ -39,7 +39,8 @@ else
     # Install Pipewire from source (done before other audio backends to minimize build time)
     export PIPEWIRE_VERSION=0.3.33
     export PIPEWIRE_URL=https://gitlab.freedesktop.org/pipewire/pipewire/-/archive
-    python -m pip install meson ninja
+    /opt/python/cp37-cp37m/bin/python -m pip install meson ninja
+    export PATH=$PATH:/opt/python/cp37-cp37m/bin
     curl $PIPEWIRE_URL/$PIPEWIRE_VERSION/pipewire-$PIPEWIRE_VERSION.tar.gz | tar -xz
     cd pipewire-$PIPEWIRE_VERSION
     ./autogen.sh --prefix=/usr
@@ -66,13 +67,13 @@ fi
 
 # Compile SDL2, addon libraries, and any necessary dependencies
 
-python -u setup.py bdist_wheel
+python3.7 -u setup.py bdist_wheel
 
 
 # Run unit tests on built pysdl2-dll wheel
 
 export SDL_VIDEODRIVER="dummy"
 export SDL_AUDIODRIVER="dummy"
-python -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
-python -m pip install pytest git+https://github.com/marcusva/py-sdl2.git
+python3.7 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
+python3.7 -m pip install pytest git+https://github.com/marcusva/py-sdl2.git
 pytest -v -rP

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -43,7 +43,7 @@ else
     curl $PIPEWIRE_URL/$PIPEWIRE_VERSION/pipewire-$PIPEWIRE_VERSION.tar.gz | tar -xz
     cd pipewire-$PIPEWIRE_VERSION
     ./autogen.sh --prefix=/usr
-    make & make install
+    make && make install
     cd ..
 
     # Install audio libraries and backends (ALSA, PulseAudio, JACK, sndio, NAS, libsamplerate)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -42,7 +42,8 @@ else
     python -m pip install meson ninja
     curl $PIPEWIRE_URL/$PIPEWIRE_VERSION/pipewire-$PIPEWIRE_VERSION.tar.gz | tar -xz
     cd pipewire-$PIPEWIRE_VERSION
-    ./autogen.sh --prefix=/usr && make & make install
+    ./autogen.sh --prefix=/usr
+    make & make install
     cd ..
 
     # Install audio libraries and backends (ALSA, PulseAudio, JACK, sndio, NAS, libsamplerate)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -7,7 +7,7 @@ set -e -u -x
 
 if command -v yum &> /dev/null; then
     # For manylinux2014 and earlier (based on CentOS)
-    yum install -y libtool
+    yum install -y libtool epel-release
 
     # Install audio libraries and backends (ALSA, PulseAudio, JACK, NAS, libsamplerate)
     yum install -y alsa-lib-devel pulseaudio-libs-devel jack-audio-connection-kit-devel \

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -7,11 +7,10 @@ set -e -u -x
 
 if command -v yum &> /dev/null; then
     # For manylinux2014 and earlier (based on CentOS)
-    yum install -y libtool epel-release
+    yum install -y libtool
 
     # Install audio libraries and backends (ALSA, PulseAudio, JACK, NAS, libsamplerate)
-    yum install -y alsa-lib-devel pulseaudio-libs-devel jack-audio-connection-kit-devel \
-        nas-devel libsamplerate-devel
+    yum install -y alsa-lib-devel pulseaudio-libs-devel nas-devel libsamplerate-devel
 
     # Install X11 and related libraries
     yum install -y libX11-devel libXext-devel libXrandr-devel libXcursor-devel \

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -9,8 +9,8 @@ if command -v yum &> /dev/null; then
     # For manylinux2014 and earlier (based on CentOS)
     yum install -y libtool
 
-    # Install audio libraries and backends (ALSA, PulseAudio, JACK, NAS, libsamplerate)
-    yum install -y alsa-lib-devel pulseaudio-libs-devel nas-devel libsamplerate-devel
+    # Install audio libraries and backends (ALSA, PulseAudio, libsamplerate)
+    yum install -y alsa-lib-devel pulseaudio-libs-devel libsamplerate-devel
 
     # Install X11 and related libraries
     yum install -y libX11-devel libXext-devel libXrandr-devel libXcursor-devel \
@@ -57,7 +57,6 @@ fi
 
 export SDL_VIDEODRIVER="dummy"
 export SDL_AUDIODRIVER="dummy"
-export PYTHONFAULTHANDLER=1
 /opt/python/cp37-cp37m/bin/python -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
 /opt/python/cp37-cp37m/bin/python -m pip install pytest git+https://github.com/marcusva/py-sdl2.git
 /opt/python/cp37-cp37m/bin/pytest -v -rP


### PR DESCRIPTION
This updates the SDL2 binaries to 2.0.16 for all supported platforms.

Additionally, due to a change in `SDL_Init` between 2.0.14 and 2.0.16, the `manylinux2010` Docker images are no longer able to test the compiled SDL2 binary without hard-crashing due to an old version of `dbus`. As such, the "legacy" manylinux version has also been bumped to `manylinux2014` for this PR. As a consequence of this, support for the old NAS audio backend has been dropped due to lack of availability with `manylinux2014`.