### PR TITLE
Add manylinux ARM64 wheels

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,19 +84,13 @@ task:
 
   env:
     matrix:
-      - SDL2DLL_PLATFORM: manylinux2014
-
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder
-    platform: linux
-    cpu: 4
-    memory: 4G
+      - SDL2DLL_PLATFORM: manylinux_2_24
+  
+  arm_container:
+    image: quay.io/pypa/$SDL2DLL_PLATFORM_aarch64
 
   script:
-    - docker pull quay.io/pypa/manylinux_2_24_aarch64
-    - docker run --rm -e SDL2DLL_PLATFORM=manylinux_2_24 -v `pwd`:/io --platform arm64 quay.io/pypa/manylinux_2_24_aarch64 /io/manylinux.sh
+    - ./manylinux.sh
 
   binaries_artifacts:
     path: "dist/*"
-  

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,3 +76,23 @@ task:
 
   binaries_artifacts:
     path: "dist/*"
+
+
+# Build 64-bit ARM manylinux wheel
+task:
+  name: "Build $SDL2DLL_PLATFORM (ARM64) wheel"
+
+  env:
+    matrix:
+      - SDL2DLL_PLATFORM: manylinux2014
+  
+  container:
+    image: quay.io/pypa/$SDL2DLL_PLATFORM_aarch64
+    memory: 1G
+
+  script:
+    - ./manylinux.sh
+
+  binaries_artifacts:
+    path: "dist/*"
+  

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,13 +85,17 @@ task:
   env:
     matrix:
       - SDL2DLL_PLATFORM: manylinux2014
-  
-  container:
-    image: quay.io/pypa/$SDL2DLL_PLATFORM_aarch64
-    memory: 1G
+
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder
+    platform: linux
+    cpu: 4
+    memory: 4G
 
   script:
-    - ./manylinux.sh
+    - docker pull quay.io/pypa/$SDL2DLL_PLATFORM_aarch64
+    - docker run --rm -e SDL2DLL_PLATFORM=$SDL2DLL_PLATFORM -v `pwd`:/io quay.io/pypa/$SDL2DLL_PLATFORM_aarch64 /io/manylinux.sh
 
   binaries_artifacts:
     path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,8 +94,8 @@ task:
     memory: 4G
 
   script:
-    - docker pull quay.io/pypa/manylinux2014_aarch64
-    - docker run --rm -e SDL2DLL_PLATFORM=manylinux2014 -v `pwd`:/io quay.io/pypa/manylinux2014_aarch64 /io/manylinux.sh
+    - docker pull quay.io/pypa/manylinux_2_24_aarch64
+    - docker run --rm -e SDL2DLL_PLATFORM=manylinux_2_24 -v `pwd`:/io --platform arm64 quay.io/pypa/manylinux_2_24_aarch64 /io/manylinux.sh
 
   binaries_artifacts:
     path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,8 +94,8 @@ task:
     memory: 4G
 
   script:
-    - docker pull quay.io/pypa/$SDL2DLL_PLATFORM_aarch64
-    - docker run --rm -e SDL2DLL_PLATFORM=$SDL2DLL_PLATFORM -v `pwd`:/io quay.io/pypa/$SDL2DLL_PLATFORM_aarch64 /io/manylinux.sh
+    - docker pull quay.io/pypa/manylinux2014_aarch64
+    - docker run --rm -e SDL2DLL_PLATFORM=manylinux2014 -v `pwd`:/io quay.io/pypa/manylinux2014_aarch64 /io/manylinux.sh
 
   binaries_artifacts:
     path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,6 +88,7 @@ task:
   
   arm_container:
     image: quay.io/pypa/$SDL2DLL_PLATFORM_aarch64
+    memory: 2G
 
   script:
     - ./manylinux.sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ pip install -U pysdl2
 
 ### Linux Requirements
 
-There are currently two versions the Linux wheels: one based on the `manylinux2010` standard (for 32-bit and 64-bit x86), and another based on the `manylinux_2_24` standard (for 64-bit x86 and 64-bit ARM only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
+There are currently two versions the Linux wheels: "legacy" wheels based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and "modern" wheels based on the `manylinux_2_24` standard (for 64-bit x86 and 64-bit ARM only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for additional features such as Wayland windowing, Pipewire/sndio/JACK audio, and OpenGL ES v1 rendering.
+
 
 You must have pip 19.0 or newer to install the `manylinux_2010` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ At present, the following platforms are supported:
 * Windows (64-bit)
 * Linux (32-bit x86)
 * Linux (64-bit x86)
+* Linux (64-bit ARM)
 
 The pysdl2-dll package can be *installed* on platforms other than the ones listed above, but it won't have any effect.
 
@@ -43,7 +44,7 @@ pip install -U pysdl2
 
 ### Linux Requirements
 
-There are currently two versions the Linux wheels: one based on the `manylinux2010` standard (for 32-bit and 64-bit x86), and another based on the `manylinux_2_24` standard (for 64-bit x86 only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
+There are currently two versions the Linux wheels: one based on the `manylinux2010` standard (for 32-bit and 64-bit x86), and another based on the `manylinux_2_24` standard (for 64-bit x86 and 64-bit ARM only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for more features such as Wayland windowing, sndio and JACK audio, and OpenGL ES v1 rendering.
 
 You must have pip 19.0 or newer to install the `manylinux_2010` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+image:
+  - Visual Studio 2019
+
 environment:
   TWINE_USERNAME: __token__ # password set in Appveyor settings
   matrix:

--- a/getdlls.py
+++ b/getdlls.py
@@ -12,7 +12,7 @@ except ImportError:
     from urllib2 import urlopen # Python 2
 
 
-libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
+libraries = ['SDL2', 'SDL2_gfx', 'SDL2_image', 'SDL2_mixer', 'SDL2_ttf']
 
 libversions = {
     'SDL2': '2.0.14',
@@ -320,7 +320,9 @@ def make_install_lib(src_path, prefix, buildenv, extra_args=None, config={}):
 
     # If updated config.guess/config.sub files provided, use those
     for name in config.keys():
-        with open(name, 'wb') as out:
+        subdir_path = os.path.join('config', name)
+        filepath = subdir_path if os.path.isfile(subdir_path) else name
+        with open(filepath, 'wb') as out:
             out.write(config[name])
 
     buildcmds = [

--- a/getdlls.py
+++ b/getdlls.py
@@ -12,7 +12,7 @@ except ImportError:
     from urllib2 import urlopen # Python 2
 
 
-libraries = ['SDL2', 'SDL2_gfx', 'SDL2_image', 'SDL2_mixer', 'SDL2_ttf']
+libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
     'SDL2': '2.0.14',


### PR DESCRIPTION
Closes #5. Adds `manylinux_2_24` wheels for ARM64, using a native ARM64 runner from Cirrus CI. Tested and working in a Debian 11 VM on an Apple Silicon Mac!

This also fixes an issue where the Appveyor runners were using an old image and the Python certificates expired, preventing pip from working.