### PR TITLE
Update SDL2 to 2.0.20 and SDL2_ttf to 2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # pysdl2-dll changelog
 
+### Version 2.0.20 (unreleased)
+
+- Bumped the SDL2 binary version from 2.0.18 to 2.0.20.
+- Bumped the SDL\_ttf binary version from 2.0.15 to 2.0.18.
+
+
 ### Version 2.0.18
 
 - Bumped the SDL2 binary version from 2.0.16 to 2.0.18.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.0.18 | 2.0.15 | 2.0.4 | 2.0.5 | 1.0.4
+2.0.20 | 2.0.18 | 2.0.4 | 2.0.5 | 1.0.4
 
 
 ## Installation

--- a/getdlls.py
+++ b/getdlls.py
@@ -355,7 +355,7 @@ def meson_install_lib(src_path, prefix, buildenv, extra_args=None):
     success = True
 
     buildcmds = [
-        ['meson' '-Dprefix={0}'.format(prefix), 'build']
+        ['meson' '-Dprefix={0}'.format(prefix), 'build'],
         ['meson', 'compile', '-C', 'build'],
         ['meson', 'install', '-C', 'build']
     ]

--- a/getdlls.py
+++ b/getdlls.py
@@ -355,7 +355,7 @@ def meson_install_lib(src_path, prefix, buildenv, extra_args=None):
     success = True
 
     buildcmds = [
-        ['meson' '-Dprefix={0}'.format(prefix), 'build'],
+        ['meson', '-Dprefix={0}'.format(prefix), 'build'],
         ['meson', 'compile', '-C', 'build'],
         ['meson', 'install', '-C', 'build']
     ]

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,9 +15,9 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.0.18',
+    'SDL2': '2.0.20',
     'SDL2_mixer': '2.0.4',
-    'SDL2_ttf': '2.0.15',
+    'SDL2_ttf': '2.0.18',
     'SDL2_image': '2.0.5',
     'SDL2_gfx': '1.0.4'
 }

--- a/getdlls.py
+++ b/getdlls.py
@@ -242,9 +242,7 @@ def buildDLLs(libraries, basedir, libdir):
             # Build any external dependencies
             extra_args = {
                 'opusfile': ['--disable-http'],
-                'freetype': ['--enable-freetype-config']
             }
-            meson_libs = ['harfbuzz']
             for dep in dependencies:
                 depname, depversion = dep.split('-')
                 dep_path = os.path.join(ext_dir, dep)

--- a/getdlls.py
+++ b/getdlls.py
@@ -215,7 +215,8 @@ def buildDLLs(libraries, basedir, libdir):
             dependencies = []
             ignore = [
                 'libvorbisidec', # only needed for special non-standard builds
-            ] 
+                'freetype', # bundled with TTF by default in latest release
+            ]
             build_first = ['zlib']
             build_last = ['libvorbis', 'opusfile', 'flac', 'harfbuzz']
             ext_dir = os.path.join(sourcepath, 'external')
@@ -255,10 +256,7 @@ def buildDLLs(libraries, basedir, libdir):
                 xtra_args = None
                 if depname in extra_args.keys():
                     xtra_args = extra_args[depname]
-                if depname in meson_libs:
-                    success = meson_install_lib(dep_path, libdir, buildenv, xtra_args)
-                else:
-                    success = make_install_lib(dep_path, libdir, buildenv, xtra_args, cfgfiles)
+                success = make_install_lib(dep_path, libdir, buildenv, xtra_args, cfgfiles)
                 if not success:
                     raise RuntimeError("Error building {0}".format(dep))
                 print('\n======= {0} built sucessfully =======\n'.format(dep))
@@ -267,7 +265,7 @@ def buildDLLs(libraries, basedir, libdir):
             print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
             xtra_args = None
             if lib == 'SDL2_ttf':
-                xtra_args = ['--with-ft-prefix={0}'.format(os.path.abspath(libdir))]
+                xtra_args = ['--enable-harfbuzz-builtin=no']
             elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
                 xtra_args = ['--disable-mmx']
             success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)

--- a/getdlls.py
+++ b/getdlls.py
@@ -215,7 +215,6 @@ def buildDLLs(libraries, basedir, libdir):
             dependencies = []
             ignore = [
                 'libvorbisidec', # only needed for special non-standard builds
-                'freetype', # bundled with TTF by default in latest release
             ]
             build_first = ['zlib']
             build_last = ['libvorbis', 'opusfile', 'flac', 'harfbuzz']
@@ -265,7 +264,11 @@ def buildDLLs(libraries, basedir, libdir):
             print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
             xtra_args = None
             if lib == 'SDL2_ttf':
-                xtra_args = ['--enable-harfbuzz-builtin=no']
+                xtra_args = [
+                    '--with-ft-prefix={0}'.format(os.path.abspath(libdir)),
+                    '--enable-freetype-builtin=no',
+                    '--enable-harfbuzz-builtin=no'
+                ]
             elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
                 xtra_args = ['--disable-mmx']
             success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)

--- a/getdlls.py
+++ b/getdlls.py
@@ -215,9 +215,11 @@ def buildDLLs(libraries, basedir, libdir):
             dependencies = []
             ignore = [
                 'libvorbisidec', # only needed for special non-standard builds
+                'freetype', # built by default in current TTF release
+                'harfbuzz', # built by default in current TTF release
             ]
             build_first = ['zlib']
-            build_last = ['libvorbis', 'opusfile', 'flac', 'harfbuzz']
+            build_last = ['libvorbis', 'opusfile', 'flac']
             ext_dir = os.path.join(sourcepath, 'external')
             if os.path.exists(ext_dir):
                 dep_dirs = os.listdir(ext_dir)
@@ -263,13 +265,7 @@ def buildDLLs(libraries, basedir, libdir):
             # Build the library
             print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
             xtra_args = None
-            if lib == 'SDL2_ttf':
-                xtra_args = [
-                    '--with-ft-prefix={0}'.format(os.path.abspath(libdir)),
-                    '--enable-freetype-builtin=no',
-                    '--enable-harfbuzz-builtin=no'
-                ]
-            elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
+            if lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
                 xtra_args = ['--disable-mmx']
             success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)
             if not success:
@@ -338,29 +334,6 @@ def make_install_lib(src_path, prefix, buildenv, extra_args=None, config={}):
     for cmd in buildcmds:
         if cmd[0] == './configure' and extra_args:
             cmd = cmd + extra_args
-        p = sub.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=buildenv)
-        p.communicate()
-        if p.returncode != 0:
-            success = False
-            break
-
-    os.chdir(orig_path)
-    return success
-
-
-def meson_install_lib(src_path, prefix, buildenv, extra_args=None):
-    """Builds and installs a library into a given prefix using meson.
-    """
-    orig_path = os.getcwd()
-    os.chdir(src_path)
-    success = True
-
-    buildcmds = [
-        ['meson', '-Dprefix={0}'.format(prefix), 'build'],
-        ['meson', 'compile', '-C', 'build'],
-        ['meson', 'install', '-C', 'build']
-    ]
-    for cmd in buildcmds:
         p = sub.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=buildenv)
         p.communicate()
         if p.returncode != 0:

--- a/getdlls.py
+++ b/getdlls.py
@@ -216,8 +216,8 @@ def buildDLLs(libraries, basedir, libdir):
             ignore = [
                 'libvorbisidec', # only needed for special non-standard builds
             ] 
-            build_first = ['zlib', 'harfbuzz']
-            build_last = ['libvorbis', 'opusfile', 'flac']
+            build_first = ['zlib']
+            build_last = ['libvorbis', 'opusfile', 'flac', 'harfbuzz']
             ext_dir = os.path.join(sourcepath, 'external')
             if os.path.exists(ext_dir):
                 dep_dirs = os.listdir(ext_dir)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -67,6 +67,7 @@ fi
 
 # Compile SDL2, addon libraries, and any necessary dependencies
 
+python3.7 -m pip install meson
 python3.7 -u setup.py bdist_wheel
 
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -67,7 +67,6 @@ fi
 
 # Compile SDL2, addon libraries, and any necessary dependencies
 
-python3.7 -m pip install meson
 python3.7 -u setup.py bdist_wheel
 
 

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.0.18"
+__version__ = "2.0.20a1"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.0.18',
+	version='2.0.20a1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',


### PR DESCRIPTION
Updates the SDL2 and SDL2\_ttf binaries to their latest versions.

Internally, the main change is that TTF 2.0.18 now builds its own FreeType and HarfBuzz libraries when built, so they don't need to be compiled externally beforehand.