### PR TITLE
Remove libudev support from manylinux wheels

### DIFF
--- a/getdlls.py
+++ b/getdlls.py
@@ -280,7 +280,7 @@ def buildDLLs(libraries, basedir, libdir):
             print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
             xtra_args = None
             if lib == 'SDL2':
-                xtra_args = ['--disable-udev']
+                xtra_args = ['--enable-udev=no']
             elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
                 xtra_args = ['--disable-mmx']
             success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)

--- a/getdlls.py
+++ b/getdlls.py
@@ -279,7 +279,9 @@ def buildDLLs(libraries, basedir, libdir):
             # Build the library
             print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
             xtra_args = None
-            if lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
+            if lib == 'SDL2':
+                xtra_args = ['--disable-udev']
+            elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
                 xtra_args = ['--disable-mmx']
             success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)
             if not success:

--- a/getdlls.py
+++ b/getdlls.py
@@ -280,7 +280,7 @@ def buildDLLs(libraries, basedir, libdir):
             print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
             xtra_args = None
             if lib == 'SDL2':
-                xtra_args = ['--enable-udev=no']
+                xtra_args = ['--enable-libudev=no']
             elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
                 xtra_args = ['--disable-mmx']
             success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -67,7 +67,7 @@ fi
 
 # If this is a tagged release, set env to strip the debug symbols from the binaries
 
-if [ -z "$CIRRUS_TAG" ]; then
+if [ -z ${CIRRUS_TAG+x} ]; then
     export SDL2DLL_RELEASE=1
 fi
 


### PR DESCRIPTION
This PR fixes joystick and game controller support with pysdl2-dll on Linux systems by dropping the problematic libudev backend, which would previously fail to be loaded dynamically at runtime (and not fall back to another input backend).

With libudev disabled, the joystick tests run perfectly fine on my Debian machine with an Xbox 360 controller.