### PR TITLE
Update SDL2 to 2.0.22

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
 
   script:
     - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
-    - python3 -m pip install pytest git+https://github.com/marcusva/py-sdl2.git
+    - python3 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
     - pytest -v -rP
 
   binaries_artifacts:
@@ -33,7 +33,7 @@ task:
 
   script:
     - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
-    - python3 -m pip install pytest git+https://github.com/marcusva/py-sdl2.git
+    - python3 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
     - pytest -v -rP
 
   binaries_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Version 2.0.22 (Unreleased)
 
 - Stripped debug symbols from manylinux binaries for smaller size.
+- Fixed joystick and gamecontroller subsystem support with the manylinux binaries by removing support for the libudev input backend. This is necessary because SDL2 doesn't fall back cleanly to another controller input API if libudev doesn't work, and udev seems to be famous for having problems with SDL2 binaries that aren't installed with the system package manager.
 
 
 ### Version 2.0.20

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.0.20 | 2.0.18 | 2.0.4 | 2.0.5 | 1.0.4
+2.0.22 | 2.0.18 | 2.0.4 | 2.0.5 | 1.0.4
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://api.cirrus-ci.com/github/a-hurst/pysdl2-dll.svg)](https://cirrus-ci.com/github/a-hurst/pysdl2-dll)
 [![Build Status](https://ci.appveyor.com/api/projects/status/lnwpe9v50bne3afu?svg=true)](https://ci.appveyor.com/project/a-hurst/pysdl2-dll)
 
-pysdl2-dll is a Python package that bundles the SDL2 binaries in pip-installable form for macOS and Windows, making it easier to create and run scripts/packages that use the [PySDL2](https://github.com/marcusva/py-sdl2) library.
+pysdl2-dll is a Python package that bundles the SDL2 binaries in pip-installable form for macOS and Windows, making it easier to create and run scripts/packages that use the [PySDL2](https://github.com/py-sdl/py-sdl2) library.
 
 It uses the official SDL2, SDL2\_mixer, SDL2\_ttf, and SDL2\_image binaries for macOS and Windows, as well as [unofficial SDL2\_gfx binaries](https://github.com/a-hurst/sdl2gfx-builds) for the same platforms. For Linux, the SDL2 binaries and their dependencies are all built from source using the official Python [manylinux](https://github.com/pypa/manylinux) images for maximum compatibility.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build: off
 
 test_script:
   - "pip install --no-index --find-links=dist pysdl2-dll"
-  - "pip install pytest git+https://github.com/marcusva/py-sdl2.git"
+  - "pip install pytest git+https://github.com/py-sdl/py-sdl2.git"
   - "pytest -v -rP"
 
 on_success:

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,7 +15,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.0.20',
+    'SDL2': '2.0.22',
     'SDL2_mixer': '2.0.4',
     'SDL2_ttf': '2.0.18',
     'SDL2_image': '2.0.5',

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -31,8 +31,8 @@ if command -v yum &> /dev/null; then
         mesa-libgbm-devel
 
     # Install input libraries
-    yum install -y dbus-devel libudev-devel ibus-devel fcitx-devel \
-        systemd-devel libxkbcommon-devel libusb-devel 
+    yum install -y dbus-devel libudev-devel ibus-devel systemd-devel \
+        libxkbcommon-devel libusb-devel
 
 else
     # For manylinux_2_24 and later (based on Debian)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -23,14 +23,16 @@ if command -v yum &> /dev/null; then
 
     # Install X11 and related libraries
     yum install -y libX11-devel libXext-devel libXrandr-devel libXcursor-devel \
-        libXinerama-devel libXi-devel libXxf86vm-devel libXScrnSaver-devel \
-        libXfixes-devel
+        libXfixes-devel libXi-devel libXinerama-devel libXxf86vm-devel \
+        libXScrnSaver-devel
 
     # Install OpenGL renderers (OpenGL, OpenGL ES v2)
-    yum install -y mesa-libGL-devel mesa-libEGL-devel mesa-libgbm-devel
+    yum install -y mesa-libGL-devel mesa-libGLES-devel mesa-libEGL-devel \
+        mesa-libgbm-devel
 
     # Install input libraries
-    yum install -y dbus-devel libudev-devel libusb-devel ibus-devel
+    yum install -y dbus-devel libudev-devel ibus-devel fcitx-devel \
+        systemd-devel libxkbcommon-devel libusb-devel 
 
 else
     # For manylinux_2_24 and later (based on Debian)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -62,6 +62,16 @@ else
     apt-get install -y libdbus-1-dev libudev-dev libusb-1.0-0-dev libibus-1.0-dev \
         fcitx-libs-dev libxkbcommon-dev
 
+    # Update Wayland to a supported version (=> 1.18.0 required as of SDL 2.0.22)
+    apt-get install -y libffi-dev libxml2-dev
+    export WAYLAND_VERSION=1.20.0
+    export WAYLAND_URL=https://gitlab.freedesktop.org/wayland/wayland/-/archive
+    curl $WAYLAND_URL/$WAYLAND_VERSION/wayland-$WAYLAND_VERSION.tar.gz | tar -xz
+    cd wayland-$WAYLAND_VERSION
+    meson build --buildtype=release -Ddocumentation=false
+    ninja -C build/ install
+    cd ..
+
 fi
 
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -94,5 +94,5 @@ python3.7 -u setup.py bdist_wheel
 export SDL_VIDEODRIVER="dummy"
 export SDL_AUDIODRIVER="dummy"
 python3.7 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
-python3.7 -m pip install pytest git+https://github.com/marcusva/py-sdl2.git
+python3.7 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
 pytest -v -rP

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.0.20"
+__version__ = "2.0.22a1"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.0.20',
+	version='2.0.22a1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,5 +41,5 @@ def test_version():
     import sdl2dll
     pkg_version = sdl2dll.__version__
     dll_version = sdl2.dll.version_tuple
-    dll_version_str = sdl2.dll.dll._version_tuple_to_str(dll_version)
+    dll_version_str = sdl2.dll._version_tuple_to_str(dll_version)
     assert dll_version_str in pkg_version

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,6 +40,6 @@ def test_version():
     import sdl2
     import sdl2dll
     pkg_version = sdl2dll.__version__
-    dll_version = sdl2.dll.version
-    dll_version_str = sdl2.dll.dll._version_int_to_str(dll_version)
+    dll_version = sdl2.dll.version_tuple
+    dll_version_str = sdl2.dll.dll._version_tuple_to_str(dll_version)
     assert dll_version_str in pkg_version


### PR DESCRIPTION
Updates the main SDL2 binary to version 2.0.22.

This PR also includes some small updates to project URLs, as well as updates the unit tests to work with the latest py-sdl2 GitHub version.