### PR TITLE
Update Image, Mixer, and TTF to latest, add Universal2 wheels

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ task:
 
 # Build macOS wheel
 task:
-  name: "Build macOS (x86_64) wheel"
+  name: "Build macOS (x86_64 & ARM64) wheels"
   
   osx_instance:
     image: monterey-base
@@ -30,6 +30,7 @@ task:
     - brew install python
     - python3 -m pip install -U wheel twine
     - python3 setup.py bdist_wheel
+    - MACOS_LEGACY_WHEEL=1 python3 setup.py bdist_wheel
 
   script:
     - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # pysdl2-dll changelog
 
+### Version 2.0.22.post1 (Unreleased)
+
+- Bumped the SDL2\_mixer binary version from 2.0.4 to 2.6.0
+- Bumped the SDL2\_image binary version from 2.0.5 to 2.6.0
+- Bumped the SDL2\_ttf binary version from 2.0.18 to 2.20.0
+- Migrated the build system for the mixer, image, and ttf binaries to CMake
+
+
 ### Version 2.0.22
 
 - Bumped the SDL2 binary version from 2.0.20 to 2.0.22.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ### Version 2.0.22.post1 (Unreleased)
 
-- Bumped the SDL2\_mixer binary version from 2.0.4 to 2.6.0
-- Bumped the SDL2\_image binary version from 2.0.5 to 2.6.0
+- Bumped the SDL2\_mixer binary version from 2.0.4 to 2.6.0.
+- Bumped the SDL2\_image binary version from 2.0.5 to 2.6.0..
 - Bumped the SDL2\_ttf binary version from 2.0.18 to 2.20.0
-- Migrated the build system for the mixer, image, and ttf binaries to CMake
+- Migrated the build system for the mixer, image, and ttf binaries to CMake.
+- Added universal2 wheels for Apple Silicon Macs now that all the official binaries are ARM-native.
 
 
 ### Version 2.0.22

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.0.22 | 2.0.18 | 2.0.4 | 2.0.5 | 1.0.4
+2.0.22 | 2.20.0 | 2.6.0 | 2.6.0 | 1.0.4
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install pysdl2-dll # install latest release version
 At present, the following platforms are supported:
 
 * macOS (10.7+, 64-bit x86)
-* macOS (11.0+, 64-bit xARM)
+* macOS (11.0+, 64-bit ARM)
 * Windows (32-bit x86)
 * Windows (64-bit x86)
 * Linux (32-bit x86)
@@ -44,6 +44,8 @@ pip install -U pysdl2
 ```
 
 Because the wheels are not built against any specfic version of Python, pysdl2-dll supports all versions and implementations of Python that are supported by PySDL2.
+
+**Note:** As of pysdl2-dll `2.0.22.post1`, the macOS binaries no longer have built-in support for the WebP image format in SDL\_image or the Modplug, Opus, or native MIDI backends in SDL\_mixer. This is due to changes in the official macOS binaries from the libSDL team, which will hopefully be brought back to full feature parity with the official Windows binaries in a future release.
 
 ### Linux Requirements
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@ pip install pysdl2-dll # install latest release version
 
 At present, the following platforms are supported:
 
-* macOS (10.6+, 64-bit x86*)
+* macOS (10.7+, 64-bit x86)
+* macOS (11.0+, 64-bit xARM)
 * Windows (32-bit x86)
 * Windows (64-bit x86)
 * Linux (32-bit x86)
 * Linux (64-bit x86)
 * Linux (64-bit ARM)
-
-*Apple Silicon wheels will be available as soon as official universal binaries of the SDL2\_mixer and SDL2\_image libraries are released.
 
 The pysdl2-dll package can be *installed* on platforms other than the ones listed above, but it won't have any effect.
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -451,6 +451,7 @@ def cmake_install_lib(src_path, prefix, buildenv, opts=None):
     if not opts:
         opts = {}
     opts['CMAKE_INSTALL_PREFIX'] = prefix
+    opts['CMAKE_INSTALL_LIBDIR'] = 'lib'
     opts['CMAKE_INSTALL_RPATH'] = prefix
 
     buildcmds = [

--- a/getdlls.py
+++ b/getdlls.py
@@ -16,17 +16,18 @@ libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
     'SDL2': '2.0.22',
-    'SDL2_mixer': '2.0.4',
-    'SDL2_ttf': '2.0.18',
-    'SDL2_image': '2.0.5',
+    'SDL2_mixer': '2.6.0',
+    'SDL2_ttf': '2.20.0',
+    'SDL2_image': '2.6.0',
     'SDL2_gfx': '1.0.4'
 }
 
+url_fmt = 'https://github.com/libsdl-org/SDL{LIB}/releases/download/release-{0}/SDL2{LIB}-{0}{1}'
 sdl2_urls = {
     'SDL2': 'https://www.libsdl.org/release/SDL2-{0}{1}',
-    'SDL2_mixer': 'https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-{0}{1}',
-    'SDL2_ttf': 'https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-{0}{1}',
-    'SDL2_image': 'https://www.libsdl.org/projects/SDL_image/release/SDL2_image-{0}{1}',
+    'SDL2_mixer': url_fmt.replace('{LIB}', '_mixer'),
+    'SDL2_ttf': url_fmt.replace('{LIB}', '_ttf'),
+    'SDL2_image': url_fmt.replace('{LIB}', '_image'),
     'SDL2_gfx': 'https://github.com/a-hurst/sdl2gfx-builds/releases/download/{0}/SDL2_gfx-{0}{1}'
 }
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -191,8 +191,9 @@ def getDLLs(platform_name):
                 if os.path.islink(fpath):
                     fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
-                libname_fixed = '.'.join(libname.split('.')[:3])
-                lib_outpath = os.path.join(dlldir, libname_fixed)
+                if libname.split('.')[0] in ['libogg', 'libopus']:
+                    libname = '.'.join(libname.split('.')[:3])
+                lib_outpath = os.path.join(dlldir, libname)
                 shutil.copy(fpath, lib_outpath)
 
         # Update library runpaths to allow loading from within sdl2dll folder

--- a/getdlls.py
+++ b/getdlls.py
@@ -44,6 +44,7 @@ cmake_opts = {
         'SDL2IMAGE_VENDORED': 'ON',
         'SDL2IMAGE_TIF': 'ON',
         'SDL2IMAGE_WEBP': 'ON',
+        'WEBP_HAVE_FLAG_SSE41': '0', # Don't require SSE4.1 at runtime
     }
 }
 
@@ -260,8 +261,6 @@ def buildDLLs(libraries, basedir, libdir):
             if lib in cmake_opts.keys():
                 # Build using CMake
                 opts = cmake_opts[lib]
-                if arch == 'i686':
-                    opts['CMAKE_CXX_FLAGS'] = "-msse2" # WebP needs SSE2 to not crash
                 success = cmake_install_lib(sourcepath, libdir, buildenv, opts)
             else:
                 # Build using autotools

--- a/getdlls.py
+++ b/getdlls.py
@@ -390,6 +390,7 @@ def cmake_install_lib(src_path, prefix, buildenv, opts=None):
     opts['CMAKE_INSTALL_PREFIX'] = prefix
     opts['CMAKE_INSTALL_LIBDIR'] = 'lib'
     opts['CMAKE_INSTALL_RPATH'] = prefix
+    opts['CMAKE_BUILD_TYPE'] = 'Debug'
 
     buildcmds = [
         ['cmake', '..'] + build_cmake_opts(opts),

--- a/getdlls.py
+++ b/getdlls.py
@@ -260,7 +260,7 @@ def buildDLLs(libraries, basedir, libdir):
             if lib in cmake_opts.keys():
                 # Build using CMake
                 opts = cmake_opts[lib]
-                if arch == 'i386':
+                if arch == 'i686':
                     opts['CMAKE_CXX_FLAGS'] = "-msse2" # WebP needs SSE2 to not crash
                 success = cmake_install_lib(sourcepath, libdir, buildenv, opts)
             else:
@@ -268,7 +268,7 @@ def buildDLLs(libraries, basedir, libdir):
                 xtra_args = None
                 if lib == 'SDL2':
                     xtra_args = ['--enable-libudev=no']
-                elif lib == 'SDL2_gfx' and not arch in ['i386', 'x86_64']:
+                elif lib == 'SDL2_gfx' and not arch in ['i686', 'x86_64']:
                     xtra_args = ['--disable-mmx']
                 success = make_install_lib(sourcepath, libdir, buildenv, xtra_args, cfgfiles)
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -260,6 +260,8 @@ def buildDLLs(libraries, basedir, libdir):
             if lib in cmake_opts.keys():
                 # Build using CMake
                 opts = cmake_opts[lib]
+                if arch == 'i386':
+                    opts['CMAKE_CXX_FLAGS'] = "-msse2" # WebP needs SSE2 to not crash
                 success = cmake_install_lib(sourcepath, libdir, buildenv, opts)
             else:
                 # Build using autotools

--- a/getdlls.py
+++ b/getdlls.py
@@ -119,8 +119,7 @@ def getDLLs(platform_name):
                 optdir = os.path.join(d, 'optional')
                 if os.path.isdir(optdir):
                     for f in os.listdir(optdir):
-                        outpath = os.path.join(d, os.path.basename(f))
-                        shutil.move(f, outpath)
+                        shutil.move(os.path.join(optdir, f), os.path.join(d, f))
 
     elif 'manylinux' in platform_name or os.getenv('SDL2DLL_UNIX_COMPILE', '0') == '1':
 
@@ -150,8 +149,7 @@ def getDLLs(platform_name):
             optdir = os.path.join(licensedir, 'optional')
             if os.path.isdir(optdir):
                 for f in os.listdir(optdir):
-                    outpath = os.path.join(licensedir, os.path.basename(f))
-                    shutil.move(f, outpath)
+                    shutil.move(os.path.join(optdir, f), os.path.join(licensedir, f))
 
         # Build and install everything into the custom prefix
         sdl2_urls['SDL2_gfx'] = 'http://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-{0}{1}'

--- a/getdlls.py
+++ b/getdlls.py
@@ -254,7 +254,7 @@ def buildDLLs(libraries, basedir, libdir):
             download_sh = os.path.join(ext_dir, 'download.sh')
             if os.path.exists(ext_dir):
                 if os.path.exists(download_sh):
-                    print('======= Downloading optional dependencies for {0} =======\n'.format(lib))
+                    print('\n======= Downloading optional libraries for {0} =======\n'.format(lib))
                     download_external(ext_dir)
                 dep_dirs = os.listdir(ext_dir)
                 deps_first, deps, deps_last = ([], [], [])
@@ -378,6 +378,8 @@ def make_install_lib(src_path, prefix, buildenv, extra_args=None, config={}):
         ['make', '-j2'],
         ['make', 'install']
     ]
+    if not os.path.exists("configure"):
+        buildcmds = ['./autogen.sh'] + buildcmds
     for cmd in buildcmds:
         if cmd[0] == './configure' and extra_args:
             cmd = cmd + extra_args

--- a/getdlls.py
+++ b/getdlls.py
@@ -32,7 +32,7 @@ sdl2_urls = {
 }
 
 override_urls = {
-    'libwebp': 'http://storage.googleapis.com/downloads.webmproject.org/releases/webp/{0}.tar.gz'
+    #'libwebp': 'http://storage.googleapis.com/downloads.webmproject.org/releases/webp/{0}.tar.gz'
 }
 
 
@@ -262,7 +262,7 @@ def buildDLLs(libraries, basedir, libdir):
                     dep_path = os.path.join(ext_dir, dep)
                     if not os.path.isdir(dep_path):
                         continue
-                    depname, depversion = dep.split('-')
+                    depname = dep.split('-')[0]
                     if depname in ignore:
                         continue
                     elif depname in build_first:
@@ -278,7 +278,7 @@ def buildDLLs(libraries, basedir, libdir):
                 'opusfile': ['--disable-http'],
             }
             for dep in dependencies:
-                depname, depversion = dep.split('-')
+                depname = dep.split('-')[0]
                 dep_path = os.path.join(ext_dir, dep)
                 if depname in override_urls.keys():
                     print('======= Downloading alternate source for {0} =======\n'.format(dep))

--- a/getdlls.py
+++ b/getdlls.py
@@ -245,6 +245,7 @@ def buildDLLs(libraries, basedir, libdir):
             dependencies = []
             ignore = [
                 'libvorbisidec', # only needed for special non-standard builds
+                'tremor', # only for platforms that can't do floating point math
                 'freetype', # built by default in current TTF release
                 'harfbuzz', # built by default in current TTF release
             ]
@@ -254,8 +255,9 @@ def buildDLLs(libraries, basedir, libdir):
             download_sh = os.path.join(ext_dir, 'download.sh')
             if os.path.exists(ext_dir):
                 if os.path.exists(download_sh):
-                    print('\n======= Downloading optional libraries for {0} =======\n'.format(lib))
+                    print('======= Downloading optional libraries for {0} =======\n'.format(lib))
                     download_external(ext_dir)
+                    print('')
                 dep_dirs = os.listdir(ext_dir)
                 deps_first, deps, deps_last = ([], [], [])
                 for dep in dep_dirs:

--- a/getdlls.py
+++ b/getdlls.py
@@ -396,7 +396,10 @@ def cmake_install_lib(src_path, prefix, buildenv, opts=None):
     opts['CMAKE_INSTALL_PREFIX'] = prefix
     opts['CMAKE_INSTALL_LIBDIR'] = 'lib'
     opts['CMAKE_INSTALL_RPATH'] = prefix
-    opts['CMAKE_BUILD_TYPE'] = 'Debug'
+    if os.getenv("SDL2DLL_RELEASE", 0) == 1:
+        opts['CMAKE_BUILD_TYPE'] = 'Release'
+    else:
+        opts['CMAKE_BUILD_TYPE'] = 'Debug'
 
     buildcmds = [
         ['cmake', '..'] + build_cmake_opts(opts),

--- a/getdlls.py
+++ b/getdlls.py
@@ -170,7 +170,9 @@ def getDLLs(platform_name):
         # Copy all compiled binaries to dll folder for bundling in wheel
         for f in os.listdir(os.path.join(libdir, 'lib')):
             fpath = os.path.join(libdir, 'lib', f)
-            if f.split('.')[-1] == "so" and not os.path.islink(fpath):
+            if f.split('.')[-1] == "so":
+                if os.path.islink(fpath):
+                    fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
                 if libname.split('.')[0] in ['libogg', 'libopus']:
                     # libopusfile expects truncated .so names

--- a/getdlls.py
+++ b/getdlls.py
@@ -296,6 +296,12 @@ def buildDLLs(libraries, basedir, libdir):
             # If requested, build library and dependencies using CMake
             if lib in cmake_opts.keys():
                 opts = cmake_opts[lib]
+                if lib == "SDL2_mixer":
+                    # Work around bug in current CMakeLists.txt
+                    cmake_txt = os.path.join(sourcepath, "CMakeLists.txt")
+                    old = "SDL2MIXER_FLAC_LIBFLAC_SHARED OR NOT"
+                    new = "SDL2MIXER_MOD_MODPLUG_SHARED OR NOT"
+                    patch_file(cmake_txt, old, new)
                 print('======= Compiling {0} {1} =======\n'.format(lib, libversion))
                 success = cmake_install_lib(sourcepath, libdir, buildenv, opts)
                 if not success:
@@ -538,6 +544,15 @@ def strip_debug_symbols(libdir):
             break
 
     return success
+
+
+def patch_file(fpath, find, replace):
+    """Finds and replaces a given string in a file.
+    """
+    with open(fpath, 'r') as f:
+        content = f.read()
+    with open(fpath, 'w') as f:
+        f.write(content.replace(find, replace))
 
 
 if __name__ == '__main__':

--- a/getdlls.py
+++ b/getdlls.py
@@ -40,6 +40,10 @@ cmake_opts = {
         'SDL2MIXER_VENDORED': 'ON',
         'SDL2MIXER_FLAC_LIBFLAC': 'OFF', # Match macOS and Windows binaries, which use dr_flac
     },
+    'SDL2_ttf': {
+        'SDL2TTF_VENDORED': 'ON',
+        'SDL2TTF_HARFBUZZ': 'ON',
+    },
     'SDL2_image': {
         'SDL2IMAGE_VENDORED': 'ON',
         'SDL2IMAGE_TIF': 'ON',
@@ -195,7 +199,8 @@ def getDLLs(platform_name):
         set_relative_runpaths(dlldir)
 
         # Rename zlib to avoid name collision with Python's zlib
-        rename_library(dlldir, 'libz', 'libz-pysdl2', fix_links=['libpng16'])
+        if any(['libz' in name for name in os.listdir(dlldir)]):
+            rename_library(dlldir, 'libz', 'libz-pysdl2', fix_links=['libpng16'])
 
         # If release, strip debug symbols from the binaries to reduce file size
         if os.getenv("SDL2DLL_RELEASE", 0) == 1:

--- a/getdlls.py
+++ b/getdlls.py
@@ -450,6 +450,7 @@ def cmake_install_lib(src_path, prefix, buildenv, opts=None):
     if not opts:
         opts = {}
     opts['CMAKE_INSTALL_PREFIX'] = prefix
+    opts['CMAKE_INSTALL_RPATH'] = prefix
 
     buildcmds = [
         ['cmake', '..'] + build_cmake_opts(opts),

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -79,8 +79,9 @@ fi
 
 # If this is a tagged release, set env to strip the debug symbols from the binaries
 
-if [ ! -z "$CIRRUS_TAG" ]; then
+if [ ! -z ${CIRRUS_TAG:-} ]; then
     export SDL2DLL_RELEASE=1
+    echo "Building version ${CIRRUS_TAG} for release"
 fi
 
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -79,7 +79,7 @@ fi
 
 # If this is a tagged release, set env to strip the debug symbols from the binaries
 
-if [ ! -z $CIRRUS_TAG ]; then
+if [ ! -z "$CIRRUS_TAG" ]; then
     export SDL2DLL_RELEASE=1
 fi
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -79,7 +79,7 @@ fi
 
 # If this is a tagged release, set env to strip the debug symbols from the binaries
 
-if [ -z ${CIRRUS_TAG+x} ]; then
+if [ ! -z $CIRRUS_TAG ]; then
     export SDL2DLL_RELEASE=1
 fi
 

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.0.22"
+__version__ = "2.0.22.post1"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.0.22',
+	version='2.0.22.post1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ try:
 
         def get_tag(self):
             if 'macosx' in platform:
-                system = 'macosx_10_6_x86_64'
+                system = 'macosx_10_7_universal2'
+                if os.getenv('MACOS_LEGACY_WHEEL'):
+                    system = 'macosx_10_7_x86_64'
             elif platform in ['win32', 'win-amd64']:
                 system = platform.replace('-', '_')
             elif 'manylinux' in platform:

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -5,6 +5,7 @@ import pytest
 
 platform = os.getenv('SDL2DLL_PLATFORM')
 manylinux = platform and 'manylinux' in platform
+is_macos = sys.platform == 'darwin'
 nodlls = not manylinux and sys.platform not in ('win32', 'darwin')
 pytestmark = pytest.mark.skipif(nodlls, reason="No binaries for this platform")
 
@@ -113,7 +114,11 @@ def test_sdl2mixer_formats():
     print(supported)
 
     # Ensure all available formats supported by binaries
-    assert len(supported) == len(libs.keys())
+    # NOTE: Temporary workaround missing binaries in official .dmg
+    if is_macos:
+        assert len(supported) > 0
+    else:
+        assert len(supported) == len(libs.keys())
 
 
 def test_sdl2image_formats():
@@ -146,4 +151,8 @@ def test_sdl2image_formats():
     print(supported)
 
     # Ensure all available formats supported by binaries
-    assert len(supported) == len(libs.keys())
+    # NOTE: Temporary workaround missing binaries in official .dmg
+    if is_macos:
+        assert len(supported) > 0
+    else:
+        assert len(supported) == len(libs.keys())


### PR DESCRIPTION
This PR adds support for `SDL2_mixer` 2.6.0, `SDL2_image` 2.6.0, and `SDL2_ttf` 2.20.0, and also adds proper wheels for Apple Silicon Macs in the process (closing #14).

In order to add manylinux support for the new versions, support was added in the build script for building libraries and their external optional dependencies with CMake. TTF, Image, and Mixer are now all built this way, and SDL2 itself can likely be migrated to this (much faster and easier) build system with its next release. 

The minimum macOS version is now bumped to 10.7, since I actually tested the package out on an old MacBook and it worked properly on Lion but not Snow Leopard.