### PR TITLE
Update SDL2 to 2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # pysdl2-dll changelog
 
+### Version 2.24.0 (Unreleased)
+
+- Bumped the SDL2 binary version from 2.0.22 to 2.24.0.
+
+
 ### Version 2.0.22.post1
 
 - Bumped the SDL2\_mixer binary version from 2.0.4 to 2.6.0.
-- Bumped the SDL2\_image binary version from 2.0.5 to 2.6.0..
-- Bumped the SDL2\_ttf binary version from 2.0.18 to 2.20.0
+- Bumped the SDL2\_image binary version from 2.0.5 to 2.6.0.
+- Bumped the SDL2\_ttf binary version from 2.0.18 to 2.20.0.
 - Migrated the build system for the mixer, image, and ttf binaries to CMake.
 - Added universal2 wheels for Apple Silicon Macs now that all the official binaries are ARM-native.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.0.22 | 2.20.0 | 2.6.0 | 2.6.0 | 1.0.4
+2.24.0 | 2.20.0 | 2.6.0 | 2.6.0 | 1.0.4
 
 
 ## Installation

--- a/getdlls.py
+++ b/getdlls.py
@@ -33,10 +33,11 @@ sdl2_urls = {
 }
 
 cmake_opts = {
-    'SDL2': {
-        'SDL_SSE2': 'ON',
-        'SDL_ARMNEON': 'ON',
-    },
+    # CMake currently broken with the 2.23.1 .tar.gz
+    #'SDL2': {
+    #    'SDL_SSE2': 'ON',
+    #    'SDL_ARMNEON': 'ON',
+    #},
     'SDL2_mixer': {
         'SDL2MIXER_VENDORED': 'ON',
         'SDL2MIXER_FLAC_LIBFLAC': 'OFF', # Match macOS and Windows binaries, which use dr_flac

--- a/getdlls.py
+++ b/getdlls.py
@@ -33,11 +33,10 @@ sdl2_urls = {
 }
 
 cmake_opts = {
-    # CMake currently broken with the 2.23.1 .tar.gz
-    #'SDL2': {
-    #    'SDL_SSE2': 'ON',
-    #    'SDL_ARMNEON': 'ON',
-    #},
+    'SDL2': {
+        'SDL_SSE2': 'ON',
+        'SDL_ARMNEON': 'ON',
+    },
     'SDL2_mixer': {
         'SDL2MIXER_VENDORED': 'ON',
         'SDL2MIXER_FLAC_LIBFLAC': 'OFF', # Match macOS and Windows binaries, which use dr_flac

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,7 +15,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.23.2',
+    'SDL2': '2.24.0',
     'SDL2_mixer': '2.6.0',
     'SDL2_ttf': '2.20.0',
     'SDL2_image': '2.6.0',
@@ -33,10 +33,10 @@ sdl2_urls = {
 }
 
 cmake_opts = {
-    'SDL2': {
-        'SDL_SSE2': 'ON',
-        'SDL_ARMNEON': 'ON',
-    },
+    #'SDL2': {
+    #    'SDL_SSE2': 'ON',
+    #    'SDL_ARMNEON': 'ON',
+    #},
     'SDL2_mixer': {
         'SDL2MIXER_VENDORED': 'ON',
         'SDL2MIXER_FLAC_LIBFLAC': 'OFF', # Match macOS and Windows binaries, which use dr_flac

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,7 +15,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.0.22',
+    'SDL2': '2.23.1',
     'SDL2_mixer': '2.6.0',
     'SDL2_ttf': '2.20.0',
     'SDL2_image': '2.6.0',
@@ -23,8 +23,9 @@ libversions = {
 }
 
 url_fmt = 'https://github.com/libsdl-org/SDL{LIB}/releases/download/release-{0}/SDL2{LIB}-{0}{1}'
+url_fmt_pre = url_fmt.replace('release-', 'prerelease-')
 sdl2_urls = {
-    'SDL2': 'https://www.libsdl.org/release/SDL2-{0}{1}',
+    'SDL2': url_fmt_pre.replace('{LIB}', ''),
     'SDL2_mixer': url_fmt.replace('{LIB}', '_mixer'),
     'SDL2_ttf': url_fmt.replace('{LIB}', '_ttf'),
     'SDL2_image': url_fmt.replace('{LIB}', '_image'),

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,7 +15,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.23.1',
+    'SDL2': '2.23.2',
     'SDL2_mixer': '2.6.0',
     'SDL2_ttf': '2.20.0',
     'SDL2_image': '2.6.0',

--- a/getdlls.py
+++ b/getdlls.py
@@ -33,6 +33,10 @@ sdl2_urls = {
 }
 
 cmake_opts = {
+    'SDL2': {
+        'SDL_SSE2': 'ON',
+        'SDL_ARMNEON': 'ON',
+    },
     'SDL2_mixer': {
         'SDL2MIXER_VENDORED': 'ON',
         'SDL2MIXER_FLAC_LIBFLAC': 'OFF', # Match macOS and Windows binaries, which use dr_flac

--- a/getdlls.py
+++ b/getdlls.py
@@ -25,7 +25,7 @@ libversions = {
 url_fmt = 'https://github.com/libsdl-org/SDL{LIB}/releases/download/release-{0}/SDL2{LIB}-{0}{1}'
 url_fmt_pre = url_fmt.replace('release-', 'prerelease-')
 sdl2_urls = {
-    'SDL2': url_fmt_pre.replace('{LIB}', ''),
+    'SDL2': url_fmt.replace('{LIB}', ''),
     'SDL2_mixer': url_fmt.replace('{LIB}', '_mixer'),
     'SDL2_ttf': url_fmt.replace('{LIB}', '_ttf'),
     'SDL2_image': url_fmt.replace('{LIB}', '_image'),

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.23.1.pre1"
+__version__ = "2.23.2.pre1"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.23.2.pre1"
+__version__ = "2.24.0"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.0.22.post1"
+__version__ = "2.23.1.pre1"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.23.2.pre1',
+	version='2.24.0',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.23.1.pre1',
+	version='2.23.2.pre1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.0.22.post1',
+	version='2.23.1.pre1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',


### PR DESCRIPTION
This updates the SDL2 binaries to the latest stable release, 2.24.0.

Note that although the getdlls.py framework supports building SDL2 with CMake now, it's still considered a work-in-progress by libSDL and it also seems to break the build process for SDL2\_gfx (can't find the library to link to, probably an easy fix). Will probably revisit for the next SDL2 release.