### PR TITLE
Update SDL2 to 2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # pysdl2-dll changelog
 
+### Version 2.26.0
+
+- Bumped the SDL2 binary version from 2.24.2 to 2.26.0.
+
+
 ### Version 2.24.2
 
 - Bumped the SDL2 binary version from 2.24.1 to 2.24.2.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.24.2 | 2.20.0 | 2.6.0 | 2.6.0 | 1.0.4
+2.26.0 | 2.20.0 | 2.6.0 | 2.6.0 | 1.0.4
 
 
 ## Installation

--- a/getdlls.py
+++ b/getdlls.py
@@ -15,7 +15,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.24.2',
+    'SDL2': '2.26.0',
     'SDL2_mixer': '2.6.0',
     'SDL2_ttf': '2.20.0',
     'SDL2_image': '2.6.0',

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.24.2"
+__version__ = "2.26.0"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.24.2',
+	version='2.26.0',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',


### PR DESCRIPTION
This PR bumps the SDL2 binaries to the latest official release, 2.26.0.