### PR TITLE
Update manylinux_2_24 to manylinux_2_28

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,7 +85,7 @@ task:
   env:
     matrix:
       - SDL2DLL_PLATFORM: manylinux2014
-      - SDL2DLL_PLATFORM: manylinux_2_24
+      - SDL2DLL_PLATFORM: manylinux_2_28
   
   container:
     image: quay.io/pypa/$SDL2DLL_PLATFORM_x86_64
@@ -110,7 +110,7 @@ task:
 
   env:
     matrix:
-      - SDL2DLL_PLATFORM: manylinux_2_24
+      - SDL2DLL_PLATFORM: manylinux_2_28
   
   arm_container:
     image: quay.io/pypa/$SDL2DLL_PLATFORM_aarch64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,9 +69,9 @@ task:
   # NOTE: cryptography 2.6.1 is the last version with a 32-bit wheel
   deploy_script: |
     if [ ! -z ${CIRRUS_TAG:-} ]; then
-      python3.7 -m pip install cryptography==2.6.1
-      python3.7 -m pip install twine
-      python3.7 -m twine upload --skip-existing dist/*.whl
+      python3.9 -m pip install cryptography==2.6.1
+      python3.9 -m pip install twine
+      python3.9 -m twine upload --skip-existing dist/*.whl
     fi
 
   binaries_artifacts:
@@ -96,8 +96,8 @@ task:
 
   deploy_script: |
     if [ ! -z ${CIRRUS_TAG:-} ]; then
-      python3.7 -m pip install twine
-      python3.7 -m twine upload --skip-existing dist/*.whl
+      python3.9 -m pip install twine
+      python3.9 -m twine upload --skip-existing dist/*.whl
     fi
 
   binaries_artifacts:
@@ -121,8 +121,8 @@ task:
 
   deploy_script: |
     if [ ! -z ${CIRRUS_TAG:-} ]; then
-      python3.7 -m pip install twine
-      python3.7 -m twine upload --skip-existing dist/*.whl
+      python3.9 -m pip install twine
+      python3.9 -m twine upload --skip-existing dist/*.whl
     fi
 
   binaries_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pysdl2-dll changelog
 
+### Version 2.26.x (Unreleased)
+
+- Updated the 'modern' Linux wheels from `manylinux_2_24` to `manylinux_2_28`. This pushes some older distros (e.g. Ubuntu < 18.04) back to the 'legacy' `manylinux2014` wheels, but adds libdecor support to the 'modern' wheels for better Wayland support.
+- Removed Network Audio System (`libaudio`) support from the 'modern' Linux wheels (if this is a problem for anyone, please let me know and I'll try to re-add it).
+- Added sndio and JACK audio support to the 'legacy' Linux wheels.
+
+
 ### Version 2.26.2
 
 - Bumped the SDL2 binary version from 2.26.1 to 2.26.2.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ Because the wheels are not built against any specfic version of Python, pysdl2-d
 
 ### Linux Requirements
 
-There are currently two versions the Linux wheels: "legacy" wheels based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and "modern" wheels based on the `manylinux_2_24` standard (for 64-bit x86 and 64-bit ARM only). The `manylinux_2_24` SDL2 binaries require a more recent version of Linux, but offer dynamic support for additional features such as Wayland windowing, Pipewire/sndio/JACK audio, and OpenGL ES v1 rendering.
+There are currently two versions the Linux wheels: "legacy" wheels based on the `manylinux2014` standard (for 32-bit and 64-bit x86), and "modern" wheels based on the `manylinux_2_28` standard (for 64-bit x86 and 64-bit ARM only). The `manylinux_2_28` SDL2 binaries require a more recent version of Linux, but offer dynamic support for additional features such as native Wayland windowing, Pipewire audio, and Vulkan rendering.
 
-You must have pip 19.3 or newer to install the `manylinux2014` wheels, and pip 20.3 or newer to install the `manylinux_2_24` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
-
-**Note**: pysdl2-dll is currently not built with libdecor support, meaning that native Wayland (non-XWayland) window decorations will be unavailable when using these binaries (see issue #9 for details). Given that SDL2 defaults to using XWayland this shouldn't be an issue for most users, but suggestions and/or PRs to fix the issue are welcome!
+You must have pip 19.3 or newer to install the `manylinux2014` wheels, and pip 20.3 or newer to install the `manylinux_2_28` wheels. Distributions that use musl C instead of glibc (e.g. Alpine Linux) are not supported.
 
 
 ## Usage

--- a/build_extras.py
+++ b/build_extras.py
@@ -52,7 +52,7 @@ extras = {
         'version': "0.126.0",
         'url': GITHUB_URL.format("jackaudio/jack1") + "{0}/jack1-{0}.tar.gz",
         'build_cmds': [
-            ['./configure', '--prefix=/usr'],
+            ['./configure', '--prefix=/usr', f'--libdir={LIBDIR}'],
             ['make'],
             ['make', 'install'],
         ]

--- a/build_extras.py
+++ b/build_extras.py
@@ -6,17 +6,20 @@ import tarfile
 from urllib.request import urlopen
 
 
-FREEDESKTOP_URL_BASE = "https://gitlab.freedesktop.org/{0}/{0}/-/archive/"
+FREEDESKTOP_URL = "https://gitlab.freedesktop.org/{0}/{0}/-/archive/"
+GITHUB_URL = "https://github.com/{0}/releases/download/"
 LIBDIR = "/usr/lib64" if sys.maxsize > 2 ** 32 else "/usr/lib"
 
 extras = {
     'pipewire': {
         'version': "0.3.58",
-        'url': FREEDESKTOP_URL_BASE.format("pipewire") + "{0}/pipewire-{0}.tar.gz",
+        'url': FREEDESKTOP_URL.format("pipewire") + "{0}/pipewire-{0}.tar.gz",
         'build_cmds': [
             ['meson', 'setup', 'builddir',
                 '-Dprefix=/usr',
                 '-Dsession-managers=',
+                '-Dspa-plugins=disabled',
+                '-Dgstreamer=disabled',
                 '-Dpipewire-alsa=disabled',
                 '-Dalsa=disabled',
                 '-Djack-devel=true',
@@ -29,7 +32,7 @@ extras = {
     },
     'libdecor': {
         'version': "0.1.1",
-        'url': FREEDESKTOP_URL_BASE.format("libdecor") + "{0}/libdecor-{0}.tar.gz",
+        'url': FREEDESKTOP_URL.format("libdecor") + "{0}/libdecor-{0}.tar.gz",
         'build_cmds': [
             ['meson', 'build', '--buildtype', 'release', '-Dprefix=/usr'],
             ['meson', 'install', '-C', 'build'],
@@ -43,6 +46,15 @@ extras = {
             ['make'],
             ['make', 'install'],
             ['ldconfig'],
+        ]
+    },
+    'jack1': {
+        'version': "0.126.0",
+        'url': GITHUB_URL.format("jackaudio/jack1") + "{0}/jack1-{0}.tar.gz",
+        'build_cmds': [
+            ['./configure', '--prefix=/usr'],
+            ['make'],
+            ['make', 'install'],
         ]
     }
 }

--- a/build_extras.py
+++ b/build_extras.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import subprocess as sub
+import tarfile
+
+from urllib.request import urlopen
+
+
+LIBDIR = "/usr/lib64" if sys.maxsize > 2 ** 32 else "/usr/lib"
+
+extras = {
+    'sndio': {
+        'version': "1.9.0",
+        'url': "https://sndio.org/sndio-{0}.tar.gz",
+        'build_cmds': [
+            ['./configure', '--prefix=/usr', f'--pkgconfdir={LIBDIR}/pkgconfig'],
+            ['make'],
+            ['make', 'install'],
+            ['ldconfig'],
+        ]
+    }
+}
+
+
+def fetch_source(liburl, outdir):
+    """Downloads and decompresses the source code for a given library.
+    """
+    # Download tarfile to temporary folder
+    srctar = urlopen(liburl)
+    srcfile = liburl.split("/")[-1]
+    outpath = os.path.join(outdir, srcfile)
+    with open(outpath, 'wb') as out:
+        out.write(srctar.read())
+
+    # Extract source from archive
+    with tarfile.open(outpath, 'r:gz') as z:
+        z.extractall(path=outdir)
+
+    return os.path.join(outdir, srcfile.replace(".tar.gz", ""))
+
+
+
+# Actually run build script
+
+libname = sys.argv[1]
+if not libname in extras.keys():
+    e = "build_extras.py is not configured to build the '{0}' library"
+    raise RuntimeError(e.format(libname))
+
+libdir = "lib_extra"
+if not os.path.exists(libdir):
+    os.mkdir(libdir)
+
+# Download and extract source code
+info = extras[libname]
+sourcedir = fetch_source(info['url'].format(info['version']), libdir)
+
+# Enter source directory and build/install the library
+os.chdir(sourcedir)
+print("\n=== Building {0} {1} from source ===\n".format(libname, info['version']))
+for cmd in info['build_cmds']:
+    p = sub.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+    p.communicate()
+    if p.returncode != 0:
+        success = False
+        break

--- a/build_extras.py
+++ b/build_extras.py
@@ -6,9 +6,35 @@ import tarfile
 from urllib.request import urlopen
 
 
+FREEDESKTOP_URL_BASE = "https://gitlab.freedesktop.org/{0}/{0}/-/archive/"
 LIBDIR = "/usr/lib64" if sys.maxsize > 2 ** 32 else "/usr/lib"
 
 extras = {
+    'pipewire': {
+        'version': "0.3.58",
+        'url': FREEDESKTOP_URL_BASE.format("pipewire") + "{0}/pipewire-{0}.tar.gz",
+        'build_cmds': [
+            ['meson', 'setup', 'builddir',
+                '-Dprefix=/usr',
+                '-Dsession-managers=',
+                '-Dpipewire-alsa=disabled',
+                '-Dalsa=disabled',
+                '-Djack-devel=true',
+                '-Dexamples=disabled',
+                '-Dtests=disabled',
+            ],
+            ['meson', 'compile', '-C', 'builddir'],
+            ['meson', 'install', '-C', 'builddir'],
+        ]
+    },
+    'libdecor': {
+        'version': "0.1.1",
+        'url': FREEDESKTOP_URL_BASE.format("libdecor") + "{0}/libdecor-{0}.tar.gz",
+        'build_cmds': [
+            ['meson', 'build', '--buildtype', 'release', '-Dprefix=/usr'],
+            ['meson', 'install', '-C', 'build'],
+        ]
+    },
     'sndio': {
         'version': "1.9.0",
         'url': "https://sndio.org/sndio-{0}.tar.gz",

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -4,7 +4,7 @@ set -e -u -x
 
 # Initialize the PATH and initial directory
 
-export PATH=/opt/python/cp37-cp37m/bin:$PATH
+export PATH=/opt/python/cp39-cp39/bin:$PATH
 
 if [ -d "/io" ]; then
     cd /io
@@ -42,7 +42,7 @@ else
     # Install Pipewire from source (done before other audio backends to minimize build time)
     export PIPEWIRE_VERSION=0.3.33
     export PIPEWIRE_URL=https://gitlab.freedesktop.org/pipewire/pipewire/-/archive
-    python3.7 -m pip install meson ninja
+    python3.9 -m pip install meson ninja
     curl $PIPEWIRE_URL/$PIPEWIRE_VERSION/pipewire-$PIPEWIRE_VERSION.tar.gz | tar -xz
     cd pipewire-$PIPEWIRE_VERSION
     ./autogen.sh --prefix=/usr
@@ -87,13 +87,13 @@ fi
 
 # Compile SDL2, addon libraries, and any necessary dependencies
 
-python3.7 -u setup.py bdist_wheel
+python3.9 -u setup.py bdist_wheel
 
 
 # Run unit tests on built pysdl2-dll wheel
 
 export SDL_VIDEODRIVER="dummy"
 export SDL_AUDIODRIVER="dummy"
-python3.7 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
-python3.7 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
+python3.9 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
+python3.9 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
 pytest -v -rP

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -35,7 +35,7 @@ if command -v yum &> /dev/null; then
         libxkbcommon-devel libusb-devel
 
 else
-    # For manylinux_2_24 and later (based on Debian)
+    # For manylinux_2_24 (based on Debian)
     apt-get update
     apt-get install -y libtool libdbus-1-dev
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -18,10 +18,19 @@ if command -v yum &> /dev/null; then
     # For manylinux2014 & manylinux_2_28 (based on CentOS)
     yum install -y libtool dbus-devel
 
+    # Install additional audio backends from source
     if [[ "$AUDITWHEEL_POLICY" == "manylinux_2_28" ]]; then
+
         # Install pipewire >= 0.3.20 from source for manylinux_2_28
         python3.9 -m pip install meson ninja
         python3.9 build_extras.py pipewire
+
+    elif [[ "$AUDITWHEEL_POLICY" == "manylinux2014" ]]; then
+
+        # Install JACK v1 from source for manylinux2014
+        yum install -y libdb-devel
+        python3.9 build_extras.py jack1
+
     fi
 
     # Install audio libraries and backends (ALSA, PulseAudio, libsamplerate)
@@ -52,13 +61,6 @@ if command -v yum &> /dev/null; then
         # Install libdecor from source
         yum install -y pango-devel
         python3.9 build_extras.py libdecor
-
-    # Install additional libraries for manylinux2014
-    elif [[ "$AUDITWHEEL_POLICY" == "manylinux2014" ]]; then
-
-        # Install JACK v1 from source
-        yum install -y libdb-devel
-        python3.9 build_extras.py jack1
 
     fi
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -28,7 +28,7 @@ if command -v yum &> /dev/null; then
 
     # Install OpenGL renderers (OpenGL, OpenGL ES v2)
     yum install -y mesa-libGL-devel mesa-libGLES-devel mesa-libEGL-devel \
-        mesa-libgbm-devel
+        mesa-libgbm-devel libdrm-devel
 
     # Install input libraries
     yum install -y dbus-devel libudev-devel ibus-devel systemd-devel \

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -57,6 +57,7 @@ if command -v yum &> /dev/null; then
     elif [[ "$AUDITWHEEL_POLICY" == "manylinux2014" ]]; then
 
         # Install JACK v1 from source
+        yum install -y libdb-devel
         python3.9 build_extras.py jack1
 
     fi

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -53,6 +53,12 @@ if command -v yum &> /dev/null; then
         yum install -y pango-devel
         python3.9 build_extras.py libdecor
 
+    # Install additional libraries for manylinux2014
+    elif [[ "$AUDITWHEEL_POLICY" == "manylinux2014" ]]; then
+
+        # Install JACK v1 from source
+        python3.9 build_extras.py jack1
+
     fi
 
 else

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -21,6 +21,9 @@ if command -v yum &> /dev/null; then
     # Install audio libraries and backends (ALSA, PulseAudio, libsamplerate)
     yum install -y alsa-lib-devel pulseaudio-libs-devel libsamplerate-devel
 
+    # Build sndio from source
+    python3.9 build_extras.py sndio
+
     # Install X11 and related libraries
     yum install -y libX11-devel libXext-devel libXrandr-devel libXcursor-devel \
         libXfixes-devel libXi-devel libXinerama-devel libXxf86vm-devel \

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -15,8 +15,14 @@ fi
 # for as many different audio/video/input backends as possible
 
 if command -v yum &> /dev/null; then
-    # For manylinux2014 and earlier (based on CentOS)
-    yum install -y libtool
+    # For manylinux2014 & manylinux_2_28 (based on CentOS)
+    yum install -y libtool dbus-devel
+
+    if [[ "$AUDITWHEEL_POLICY" == "manylinux_2_28" ]]; then
+        # Install pipewire >= 0.3.20 from source for manylinux_2_28
+        python3.9 -m pip install meson ninja
+        python3.9 build_extras.py pipewire
+    fi
 
     # Install audio libraries and backends (ALSA, PulseAudio, libsamplerate)
     yum install -y alsa-lib-devel pulseaudio-libs-devel libsamplerate-devel
@@ -34,8 +40,20 @@ if command -v yum &> /dev/null; then
         mesa-libgbm-devel libdrm-devel
 
     # Install input libraries
-    yum install -y dbus-devel libudev-devel ibus-devel systemd-devel \
-        libxkbcommon-devel libusb-devel
+    yum install -y libudev-devel ibus-devel systemd-devel libxkbcommon-devel \
+        libusb-devel
+
+    # Install additional libraries for manylinux_2_28
+    if [[ "$AUDITWHEEL_POLICY" == "manylinux_2_28" ]]; then
+
+        # Install Wayland/Vulkan libraries
+        yum install -y wayland-devel wayland-protocols-devel vulkan-devel
+
+        # Install libdecor from source
+        yum install -y pango-devel
+        python3.9 build_extras.py libdecor
+
+    fi
 
 else
     # For manylinux_2_24 (based on Debian)


### PR DESCRIPTION
The Debian 9-based `manylinux_2_24` wheels have been EOL since January and have now stopped working entirely. This PR replaces them with the new `manylinux_2_28` wheels based on AlmaLinux 8 (CentOS 8 derivative).

In addition, a new script `build_extras.py` has been added to facilitate building missing libraries from source.

**Main Changes:**
* Support for the Network Audio System (nas) backend has been removed
* Added support for libdecor to the `manylinux_2_28` wheels
* Added support for sndio and JACK audio to the `manylinux2014` wheels
