### PR TITLE
Bump SDL2 to 2.28.5 and SDL_image to 2.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.28.5 | 2.20.0 | 2.6.0 | 2.8.0 | 1.0.4
+2.28.5 | 2.20.0 | 2.6.0 | 2.8.1 | 1.0.4
 
 Note that the mixer library is pinned at its current version until its next major release due to a regression in the macOS binaries.
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.28.4 | 2.20.0 | 2.6.0 | 2.6.0 | 1.0.4
+2.28.5 | 2.20.0 | 2.6.0 | 2.8.0 | 1.0.4
 
-Note that the mixer and image libraries are pinned at their current versions until their next major release due to a regression in the macOS binaries.
+Note that the mixer library is pinned at its current version until its next major release due to a regression in the macOS binaries.
 
 
 ## Installation

--- a/getdlls.py
+++ b/getdlls.py
@@ -20,7 +20,7 @@ libversions = {
     'SDL2': '2.28.5',
     'SDL2_mixer': '2.6.0',
     'SDL2_ttf': '2.20.0',
-    'SDL2_image': '2.8.0',
+    'SDL2_image': '2.8.1',
     'SDL2_gfx': '1.0.4'
 }
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -194,7 +194,7 @@ def getDLLs(platform_name):
                     rename_dependency(fpath, 'libwebp.so.7.5.0', 'libwebp.so.1.0.3')
                 elif libname_base == 'libtiff':
                     # Work around linking issues with libtiff
-                    libname = 'libtiffs.so.5'
+                    libname = 'libtiff.so.5'
                 lib_outpath = os.path.join(dlldir, libname)
                 shutil.copy(fpath, lib_outpath)
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -187,6 +187,9 @@ def getDLLs(platform_name):
                 if libname.split('.')[0] in ['libogg', 'libopus']:
                     # libopusfile expects truncated .so names
                     libname = '.'.join(libname.split('.')[:3])
+                elif libname.split('.')[0] == 'libwebpdemux':
+                    # Work around linking issue with removing symlinks for wheel
+                    libname = 'libwebpdemux.so.2.6.0'
                 lib_outpath = os.path.join(dlldir, libname)
                 shutil.copy(fpath, lib_outpath)
 
@@ -458,11 +461,6 @@ def set_relative_runpaths(libdir):
         if p.returncode != 0:
             success = False
             break
-        # Print shared library dependencies
-        print("{0} dependencies:".format(lib))
-        cmd2 = ['readelf', '-d', lib, '|', 'grep', 'NEEDED']
-        p = sub.Popen(cmd + [lib], stdout=sys.stdout, stderr=sys.stderr)
-        p.communicate()
 
     os.chdir(orig_path)
     return success

--- a/getdlls.py
+++ b/getdlls.py
@@ -84,7 +84,7 @@ def getDLLs(platform_name):
             
             # Download disk image containing library
             outpath = os.path.join('temp', lib + '.dmg')
-            if lib in ['SDL2_image', 'SDL2_mixer']:
+            if lib in ['SDL2_mixer']:
                 # NOTE: Temporary workaround for optional frameworks until 2.8.0
                 download('https://www.libsdl.org/tmp/{0}-2.7.0.dmg'.format(lib), outpath)
             else:

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,10 +17,10 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.28.4',
+    'SDL2': '2.28.5',
     'SDL2_mixer': '2.6.0',
     'SDL2_ttf': '2.20.0',
-    'SDL2_image': '2.6.0',
+    'SDL2_image': '2.8.0',
     'SDL2_gfx': '1.0.4'
 }
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -184,13 +184,17 @@ def getDLLs(platform_name):
                 if os.path.islink(fpath):
                     fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
-                if libname.split('.')[0] in ['libogg', 'libopus']:
+                libname_base = libname.split('.')[0]
+                if libname_base in ['libogg', 'libopus']:
                     # libopusfile expects truncated .so names
                     libname = '.'.join(libname.split('.')[:3])
-                elif libname.split('.')[0] == 'libwebpdemux':
+                elif libname_base == 'libwebpdemux':
                     # Work around linking issues with libwebpdemux
                     libname = 'libwebpdemux.so.2.6.0'
                     rename_dependency(fpath, 'libwebp.so.7.5.0', 'libwebp.so.1.0.3')
+                elif libname_base == 'libtiff':
+                    # Work around linking issues with libtiff
+                    libname = 'libtiffs.so.5'
                 lib_outpath = os.path.join(dlldir, libname)
                 shutil.copy(fpath, lib_outpath)
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -458,6 +458,11 @@ def set_relative_runpaths(libdir):
         if p.returncode != 0:
             success = False
             break
+        # Print shared library dependencies
+        print("{0} dependencies:".format(lib))
+        cmd2 = ['readelf', '-d', lib, '|', 'grep', 'NEEDED']
+        p = sub.Popen(cmd + [lib], stdout=sys.stdout, stderr=sys.stderr)
+        p.communicate()
 
     os.chdir(orig_path)
     return success

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.28.4"
+__version__ = "2.28.5"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.28.4',
+	version='2.28.5',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -147,4 +147,4 @@ def test_sdl2image_formats():
     print(supported)
 
     # Ensure all available formats supported by binaries
-    assert len(supported) == len(libs.keys())
+    #assert len(supported) == len(libs.keys())

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -147,4 +147,4 @@ def test_sdl2image_formats():
     print(supported)
 
     # Ensure all available formats supported by binaries
-    #assert len(supported) == len(libs.keys())
+    assert len(supported) == len(libs.keys())


### PR DESCRIPTION
Bumps SDL2 and SDL\_image to the latest versions. The latest SDL\_image release's macOS binaries now bundle dynamic libraries for different audio formats again, so we no longer need to rely on the special version provided by the SDL team.