### PR TITLE
Update binaries to SDL2 2.30.0 and latest TTF/mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.28.5 | 2.20.0 | 2.6.0 | 2.8.1 | 1.0.4
+2.30.0 | 2.22.0 | 2.8.0 | 2.8.2 | 1.0.4
 
 Note that the mixer library is pinned at its current version until its next major release due to a regression in the macOS binaries.
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -187,8 +187,9 @@ def getDLLs(platform_name):
                     fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
                 libname_base = libname.split('.')[0]
-                if libname_base in ['libogg', 'libopus', 'libopusfile', 'libxmp', 'libwavpack']:
-                    # libopusfile expects truncated .so names
+                #if libname_base in ['libogg', 'libopus', 'libopusfile', 'libxmp', 'libwavpack']:
+                if lib == "SDL2_mixer":
+                    # Mixer uses truncated .so names?
                     libname = '.'.join(libname.split('.')[:3])
                 elif libname_base == 'libwebpdemux':
                     # Work around linking issues with libwebpdemux

--- a/getdlls.py
+++ b/getdlls.py
@@ -53,6 +53,7 @@ cmake_opts = {
         'SDL2IMAGE_TIF': 'ON',
         'SDL2IMAGE_WEBP': 'ON',
         'SDL2IMAGE_AVIF': 'ON',
+        'DAV1D_ASM': 'OFF',
     }
 }
 
@@ -187,16 +188,16 @@ def getDLLs(platform_name):
                     fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
                 libname_base = libname.split('.')[0]
-                if libname_base in ['libogg', 'libopus', 'libopusfile', 'libxmp', 'libwavpack', 'libgme', 'libavif']:
-                    # Mixer uses truncated .so names?
-                    libname = '.'.join(libname.split('.')[:3])
-                elif libname_base == 'libwebpdemux':
+                if libname_base == 'libwebpdemux':
                     # Work around linking issues with libwebpdemux
                     libname = 'libwebpdemux.so.2.6.0'
                     rename_dependency(fpath, 'libwebp.so.7.5.0', 'libwebp.so.1.0.3')
                 elif libname_base == 'libtiff':
                     # Work around linking issues with libtiff
                     libname = 'libtiff.so.5'
+                else:
+                    # SDL dynamic linking code expects truncated .so names
+                    libname = '.'.join(libname.split('.')[:3])
                 lib_outpath = os.path.join(dlldir, libname)
                 shutil.copy(fpath, lib_outpath)
 
@@ -248,6 +249,8 @@ def buildDLLs(libraries, basedir, libdir):
         cfgurl = 'https://git.savannah.gnu.org/cgit/config.git/plain/{0}'
         for name in cfgnames:
             cfgfiles[name] = urlopen(cfgurl.format(name)).read()
+
+        print("\nCurrent auditwheel policy: {0}\n".format(os.getenv("AUDITWHEEL_POLICY", "none")))
 
         for lib in libraries:
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,7 +17,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.29.3',
+    'SDL2': '2.30.0',
     'SDL2_mixer': '2.8.0',
     'SDL2_ttf': '2.22.0',
     'SDL2_image': '2.8.2',
@@ -27,7 +27,7 @@ libversions = {
 url_fmt = 'https://github.com/libsdl-org/SDL{LIB}/releases/download/release-{0}/SDL2{LIB}-{0}{1}'
 url_fmt_pre = url_fmt.replace('release-', 'prerelease-')
 sdl2_urls = {
-    'SDL2': url_fmt_pre.replace('{LIB}', ''),
+    'SDL2': url_fmt.replace('{LIB}', ''),
     'SDL2_mixer': url_fmt.replace('{LIB}', '_mixer'),
     'SDL2_ttf': url_fmt.replace('{LIB}', '_ttf'),
     'SDL2_image': url_fmt.replace('{LIB}', '_image'),

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,7 +17,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.29.2',
+    'SDL2': '2.29.3',
     'SDL2_mixer': '2.8.0',
     'SDL2_ttf': '2.22.0',
     'SDL2_image': '2.8.2',
@@ -260,7 +260,8 @@ def buildDLLs(libraries, basedir, libdir):
             # Check for and download any external dependencies
             ext_dir = os.path.join(sourcepath, 'external')
             download_sh = os.path.join(ext_dir, 'download.sh')
-            if os.path.exists(download_sh):
+            if os.path.exists(download_sh) and not lib == "SDL2_ttf":
+                # NOTE: As of 2.22.0, ttf includes external sources in .tar.gz
                 print('======= Downloading optional libraries for {0} =======\n'.format(lib))
                 download_external(ext_dir)
                 print('')

--- a/getdlls.py
+++ b/getdlls.py
@@ -187,8 +187,7 @@ def getDLLs(platform_name):
                     fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
                 libname_base = libname.split('.')[0]
-                #if libname_base in ['libogg', 'libopus', 'libopusfile', 'libxmp', 'libwavpack']:
-                if lib == "SDL2_mixer":
+                if libname_base in ['libogg', 'libopus', 'libopusfile', 'libxmp', 'libwavpack', 'libgme', 'libavif']:
                     # Mixer uses truncated .so names?
                     libname = '.'.join(libname.split('.')[:3])
                 elif libname_base == 'libwebpdemux':

--- a/getdlls.py
+++ b/getdlls.py
@@ -41,6 +41,7 @@ cmake_opts = {
     #},
     'SDL2_mixer': {
         'SDL2MIXER_VENDORED': 'ON',
+        'SDL2MIXER_GME': 'ON',
         'SDL2MIXER_FLAC_LIBFLAC': 'OFF', # Match macOS and Windows binaries, which use dr_flac
     },
     'SDL2_ttf': {
@@ -51,6 +52,7 @@ cmake_opts = {
         'SDL2IMAGE_VENDORED': 'ON',
         'SDL2IMAGE_TIF': 'ON',
         'SDL2IMAGE_WEBP': 'ON',
+        'SDL2IMAGE_AVIF': 'ON',
     }
 }
 
@@ -185,7 +187,7 @@ def getDLLs(platform_name):
                     fpath = os.path.realpath(fpath)
                 libname = os.path.basename(fpath)
                 libname_base = libname.split('.')[0]
-                if libname_base in ['libogg', 'libopus']:
+                if libname_base in ['libogg', 'libopus', 'libopusfile', 'libxmp', 'libwavpack']:
                     # libopusfile expects truncated .so names
                     libname = '.'.join(libname.split('.')[:3])
                 elif libname_base == 'libwebpdemux':

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,17 +17,17 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.28.5',
-    'SDL2_mixer': '2.6.0',
-    'SDL2_ttf': '2.20.0',
-    'SDL2_image': '2.8.1',
+    'SDL2': '2.29.2',
+    'SDL2_mixer': '2.8.0',
+    'SDL2_ttf': '2.22.0',
+    'SDL2_image': '2.8.2',
     'SDL2_gfx': '1.0.4'
 }
 
 url_fmt = 'https://github.com/libsdl-org/SDL{LIB}/releases/download/release-{0}/SDL2{LIB}-{0}{1}'
 url_fmt_pre = url_fmt.replace('release-', 'prerelease-')
 sdl2_urls = {
-    'SDL2': url_fmt.replace('{LIB}', ''),
+    'SDL2': url_fmt_pre.replace('{LIB}', ''),
     'SDL2_mixer': url_fmt.replace('{LIB}', '_mixer'),
     'SDL2_ttf': url_fmt.replace('{LIB}', '_ttf'),
     'SDL2_image': url_fmt.replace('{LIB}', '_image'),
@@ -84,7 +84,7 @@ def getDLLs(platform_name):
             
             # Download disk image containing library
             outpath = os.path.join('temp', lib + '.dmg')
-            if lib in ['SDL2_mixer']:
+            if lib in ['nope']:
                 # NOTE: Temporary workaround for optional frameworks until 2.8.0
                 download('https://www.libsdl.org/tmp/{0}-2.7.0.dmg'.format(lib), outpath)
             else:

--- a/getdlls.py
+++ b/getdlls.py
@@ -87,12 +87,8 @@ def getDLLs(platform_name):
             
             # Download disk image containing library
             outpath = os.path.join('temp', lib + '.dmg')
-            if lib in ['nope']:
-                # NOTE: Temporary workaround for optional frameworks until 2.8.0
-                download('https://www.libsdl.org/tmp/{0}-2.7.0.dmg'.format(lib), outpath)
-            else:
-                libversion = libversions[lib]
-                download(sdl2_urls[lib].format(libversion, '.dmg'), outpath)
+            libversion = libversions[lib]
+            download(sdl2_urls[lib].format(libversion, '.dmg'), outpath)
             
             # Mount image, extract framework (and any optional frameworks), then unmount
             sub.check_call(['hdiutil', 'attach', outpath, '-mountpoint', mountpoint])
@@ -196,9 +192,10 @@ def getDLLs(platform_name):
                     # Work around linking issues with libtiff
                     libname = 'libtiff.so.5'
                 elif libname_base in ['libwebp']:
+                    # No clue why this is an exception to the below rule
                     libname = libname
                 else:
-                    # SDL dynamic linking code expects truncated .so names
+                    # SDL dynamic linking code usually expects truncated .so names
                     libname = '.'.join(libname.split('.')[:3])
                 lib_outpath = os.path.join(dlldir, libname)
                 shutil.copy(fpath, lib_outpath)
@@ -276,12 +273,6 @@ def buildDLLs(libraries, basedir, libdir):
                 print('')
 
             # Apply any patches to the source if necessary
-            #if lib == 'SDL2_mixer':
-            #    # Work around bug in 2.6.0 CMakeLists.txt
-            #    cmake_txt = os.path.join(sourcepath, 'CMakeLists.txt')
-            #    old = 'SDL2MIXER_FLAC_LIBFLAC_SHARED OR NOT'
-            #    new = 'SDL2MIXER_MOD_MODPLUG_SHARED OR NOT'
-            #    patch_file(cmake_txt, old, new)
             if lib == 'SDL2_image':
                 # Ensure libwebp isn't compiled with mandatory SSE4.1 support
                 cpu_cmake = os.path.join(ext_dir, 'libwebp', 'cmake', 'cpu.cmake')

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -16,7 +16,7 @@ fi
 
 if command -v yum &> /dev/null; then
     # For manylinux2014 & manylinux_2_28 (based on CentOS)
-    yum install -y libtool dbus-devel
+    yum install -y libtool dbus-devel nasm
 
     # Install additional audio backends from source
     if [[ "$AUDITWHEEL_POLICY" == "manylinux_2_28" ]]; then

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -125,6 +125,7 @@ python3.10 -u setup.py bdist_wheel
 
 export SDL_VIDEODRIVER="dummy"
 export SDL_AUDIODRIVER="dummy"
+export SDL_MIXER_DEBUG_MUSIC_INTERFACES=1
 python3.10 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
 python3.10 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
 pytest -v -rP

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.30.0"
+__version__ = "2.29.2"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.28.5"
+__version__ = "2.30.0"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.29.3"
+__version__ = "2.30.0"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.29.2"
+__version__ = "2.29.3"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.30.0a1',
+	version='2.29.2',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.28.5',
+	version='2.30.0a1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.29.3',
+	version='2.30.0',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.29.2',
+	version='2.29.3',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -128,7 +128,8 @@ def test_sdl2image_formats():
         'JPEG': sdlimage.IMG_INIT_JPG,
         'PNG': sdlimage.IMG_INIT_PNG,
         'TIFF': sdlimage.IMG_INIT_TIF,
-        'WEBP': sdlimage.IMG_INIT_WEBP
+        'WEBP': sdlimage.IMG_INIT_WEBP,
+        'AVIF': sdlimage.IMG_INIT_AVIF,
     }
     for lib in libs.keys():
         flags = libs[lib]

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -94,7 +94,8 @@ def test_sdl2mixer_formats():
         'MP3': sdlmixer.MIX_INIT_MP3,
         'OGG': sdlmixer.MIX_INIT_OGG,
         'MID': sdlmixer.MIX_INIT_MID,
-        'OPUS': sdlmixer.MIX_INIT_OPUS
+        'OPUS': sdlmixer.MIX_INIT_OPUS,
+        'WAVPACK': 0x00000080 # NOTE: Replace once in pysdl2
     }
     for lib in libs.keys():
         flags = libs[lib]
@@ -114,7 +115,7 @@ def test_sdl2mixer_formats():
     print(supported)
 
     # Ensure all available formats supported by binaries
-    assert len(supported) == len(libs.keys())
+    #assert len(supported) == len(libs.keys())
 
 
 def test_sdl2image_formats():

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -115,7 +115,7 @@ def test_sdl2mixer_formats():
     print(supported)
 
     # Ensure all available formats supported by binaries
-    #assert len(supported) == len(libs.keys())
+    assert len(supported) == len(libs.keys())
 
 
 def test_sdl2image_formats():


### PR DESCRIPTION
Bumps SDL2 to the latest major release (2.30.0), as well as `SDL_ttf` to 2.22.0, `SDL_mixer` to 2.8.0, and `SDL_image` to the patch release `2.8.2`.

This is a draft until SDL2 2.30.0 is officially released.