### PR TITLE
Bump SDL2 binaries to 2.30.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,8 +33,8 @@ task:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
   install_script:
-    - brew install python@3.11
-    - brew link python@3.11
+    - brew install python
+    - python3 -m pip config set global.break-system-packages true
     - python3 -m pip install -U wheel twine
     - python3 setup.py bdist_wheel
     - MACOS_LEGACY_WHEEL=1 python3 setup.py bdist_wheel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,7 @@ task:
 
   install_script:
     - brew install python@3.11
+    - brew link python@3.11
     - python3 -m pip install -U wheel twine
     - python3 setup.py bdist_wheel
     - MACOS_LEGACY_WHEEL=1 python3 setup.py bdist_wheel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ task:
   install_script:
     - brew install python
     - python3 -m pip config set global.break-system-packages true
-    - python3 -m pip install -U wheel twine
+    - python3 -m pip install -U setuptools wheel twine
     - python3 setup.py bdist_wheel
     - MACOS_LEGACY_WHEEL=1 python3 setup.py bdist_wheel
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ task:
   name: "Build sdist for unsupported platforms"
   
   container:
-    image: python:3.8
+    image: python:3.11
     cpu: 1
     memory: 1G
 
@@ -33,7 +33,7 @@ task:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
   install_script:
-    - brew install python
+    - brew install python@3.11
     - python3 -m pip install -U wheel twine
     - python3 setup.py bdist_wheel
     - MACOS_LEGACY_WHEEL=1 python3 setup.py bdist_wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Version 2.30.0
 
+- Bumped the SDL2 binary version from 2.30.0 to 2.30.1.
+
+
+### Version 2.30.0
+
 - Bumped the SDL2 binary version from 2.28.5 to 2.30.0.
 - Bumped the SDL2\_image binary version from 2.8.1 to 2.8.2.
 - Bumped the SDL2\_mixer binary version from 2.6.0 to 2.8.0.

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,7 +17,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.30.0',
+    'SDL2': '2.30.1',
     'SDL2_mixer': '2.8.0',
     'SDL2_ttf': '2.22.0',
     'SDL2_image': '2.8.2',

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.30.0"
+__version__ = "2.30.1"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.30.0',
+	version='2.30.1',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',


### PR DESCRIPTION
Updates SDL2 to the latest bugfix release.

Also fixes a problem with the macOS CI runner introduced by the latest Python update.