### PR TITLE
Bump SDL2 to 2.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # pysdl2-dll changelog
 
-### Version 2.30.0
+### Version 2.30.2
+
+- Bumped the SDL2 binary version from 2.30.1 to 2.30.2.
+
+
+### Version 2.30.1
 
 - Bumped the SDL2 binary version from 2.30.0 to 2.30.1.
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,7 +17,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.30.1',
+    'SDL2': '2.30.2',
     'SDL2_mixer': '2.8.0',
     'SDL2_ttf': '2.22.0',
     'SDL2_image': '2.8.2',

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.30.1"
+__version__ = "2.30.2"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.30.1',
+	version='2.30.2',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',


### PR DESCRIPTION
Bumps the SDL2 binary to the latest patch release.