### PR TITLE
Bump SDL2 to 2.30.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.30.9 | 2.22.0 | 2.8.0 | 2.8.2 | 1.0.4
+2.30.10 | 2.22.0 | 2.8.0 | 2.8.2 | 1.0.4
 
 
 ## Installation

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,7 +17,7 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.30.9',
+    'SDL2': '2.30.10',
     'SDL2_mixer': '2.8.0',
     'SDL2_ttf': '2.22.0',
     'SDL2_image': '2.8.2',

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.30.9"
+__version__ = "2.30.10"
 
 import os
 from .initcheck import is_sdist, init_check

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open('README.md', 'r') as f:
 
 setup(
 	name='pysdl2-dll',
-	version='2.30.9',
+	version='2.30.10',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
     license='Mozilla Public License Version 2.0',


### PR DESCRIPTION
Bumps the SDL2 binaries to the latest patch release.