### PR TITLE
Align build process better with setuptools

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
     - python3 -m build -s
 
   script:
-    - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
+    - python3 -m pip install -U --force-reinstall ./dist/pysdl2-dll*.tar.gz
     - python3 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
     - pytest -v -rP
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     memory: 1G
 
   install_script:
-    - python3 -m pip install build
+    - python3 -m pip install setuptools build
     - python3 -m build -s
 
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
     - python3 -m build -s
 
   script:
-    - python3 -m pip install -U --force-reinstall ./dist/pysdl2-dll*.tar.gz
+    - python3 -m pip install -U --force-reinstall ./dist/pysdl2_dll*.tar.gz
     - python3 -m pip install pytest git+https://github.com/py-sdl/py-sdl2.git
     - pytest -v -rP
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
     - brew install python
     - python3 -m pip config set global.break-system-packages true
     - python3 -m pip install -U setuptools build twine
-    - python3 -m build
+    - python3 -m build -w
     - python3 fix_wheels.py
 
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ task:
     - python3 -m pip config set global.break-system-packages true
     - python3 -m pip install -U setuptools build twine
     - python3 -m build
-    - MACOS_LEGACY_WHEEL=1 python3 -m build
+    - python3 fix_wheels.py
 
   script:
     - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,8 @@ task:
     memory: 1G
 
   install_script:
-    - python setup.py sdist
+    - python3 -m pip install build
+    - python3 -m build -s
 
   script:
     - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll
@@ -35,9 +36,9 @@ task:
   install_script:
     - brew install python
     - python3 -m pip config set global.break-system-packages true
-    - python3 -m pip install -U setuptools wheel twine
-    - python3 setup.py bdist_wheel
-    - MACOS_LEGACY_WHEEL=1 python3 setup.py bdist_wheel
+    - python3 -m pip install -U setuptools build twine
+    - python3 -m build
+    - MACOS_LEGACY_WHEEL=1 python3 -m build
 
   script:
     - python3 -m pip install -U --force-reinstall --no-index --find-links=./dist pysdl2-dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,14 @@ image:
 environment:
   TWINE_USERNAME: __token__ # password set in Appveyor settings
   matrix:
-    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python310"
       PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python310-x64"
       PYTHON_ARCH: "64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "pip install build twine"
+  - "pip install -U setuptools wheel build twine"
   - "python -m build"
   - "python fix_wheels.py"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "pip install build twine"
   - "python -m build"
+  - "python fix_wheels.py"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "pip install -U setuptools wheel build twine"
-  - "python -m build"
+  - "python -m build -w"
   - "python fix_wheels.py"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "pip install wheel twine"
-  - "python setup.py bdist_wheel"
+  - "pip install build twine"
+  - "python -m build"
 
 build: off
 

--- a/fix_wheels.py
+++ b/fix_wheels.py
@@ -1,20 +1,68 @@
 import os
 import sys
 import glob
+import tempfile
 import subprocess as sub
+from zipfile import ZipFile
 from sysconfig import get_platform
 
-override = os.getenv('SDL2DLL_PLATFORM')
-platform = get_platform() if not override else override
+from getdlls import libraries, libversions, sdl2_urls, download
 
 
-def find_wheel():
-    if os.path.isdir('dist'):
-        wheels = glob.glob("dist/pysdl2_dll*.whl")
+def find_wheel(d):
+    if os.path.isdir(d):
+        wheels = glob.glob(os.path.join(d, "pysdl2_dll*.whl"))
         if len(wheels):
             return wheels[0]
     return None
 
+def unpack_wheel(path, outdir):
+    base_cmd = [sys.executable, '-m', 'wheel', 'unpack']
+    sub.run(base_cmd + ['--dest', outdir, path], check=True)
+    dirname = os.listdir(outdir)[0]
+    return os.path.join(outdir, dirname)
+
+def repack_wheel(wheeldir, outdir):
+    base_cmd = [sys.executable, '-m', 'wheel', 'pack']
+    sub.run(base_cmd + ['--dest-dir', outdir, wheeldir], check=True)
+    if not find_wheel(outdir):
+        raise RuntimeError("Failed to repack wheel!")
+
+def add_licenses(wheeldir):
+    distdir = os.path.join(wheeldir, os.path.basename(wheeldir) + '.dist-info')
+    zipdir = tempfile.mkdtemp(prefix='pysdl2-dll-libs')
+    licensedir = os.path.join(distdir, 'licenses', 'libs')
+    metadata_path = os.path.join(distdir, 'METADATA')
+    new_licenses = []
+
+    # Download and use license files from official Windows x64 binaries
+    # NOTE: This assumes bundled binaries are in sync across platforms
+    os.mkdir(licensedir)
+    for lib in libraries:
+        # Download zip archive containing library
+        libversion = libversions[lib]
+        outpath = os.path.join(zipdir, lib + '.zip')
+        download(sdl2_urls[lib].format(libversion, '-win32-x64.zip'), outpath)
+
+        # Extract license files from archive
+        license_libdir = os.path.join(licensedir, lib)
+        os.mkdir(license_libdir)
+        with ZipFile(outpath, 'r') as z:
+            for name in z.namelist():
+                if 'LICENSE' in name or 'README' in name:
+                    fname = name.split('/')[-1]
+                    new_licenses.append('License-File: libs/' + lib + '/' + fname)
+                    outpath = os.path.join(license_libdir, fname)
+                    with open(outpath, 'wb') as f:
+                        f.write(z.read(name))
+
+    # Update METADATA file with new licences
+    with open(metadata_path, 'r') as f:
+        metadata = f.read()
+    updated = '\n'.join(['License-File: LICENSE'] + new_licenses)
+    new_metadata = metadata.replace('License-File: LICENSE', updated)
+    with open(metadata_path, 'w') as f:
+        f.write(new_metadata)
 
 def retag_wheel(path, platform, replace=True):
     base_cmd = [sys.executable, '-m', 'wheel', 'tags']
@@ -29,17 +77,32 @@ def retag_wheel(path, platform, replace=True):
     sub.run(cmd, check=True)
 
 
-wpath = find_wheel()
-if not wpath:
+
+# Add SDL2 + bundled dynamic library licenses to wheels for distribution
+
+wheelpath = find_wheel('dist')
+if not wheelpath:
     raise RuntimeError("No wheels found in dist!")
 
+tmpdir = tempfile.mkdtemp(prefix='pysdl2-dll-wheel')
+wheeldir = unpack_wheel(wheelpath, tmpdir)
+add_licenses(wheeldir)
+os.rename(wheelpath, wheelpath + '.bak')
+repack_wheel(wheeldir, 'dist')
+
+
+# Update wheel tags to reflect platform-specific binaries
+
+override = os.getenv('SDL2DLL_PLATFORM')
+platform = get_platform() if not override else override
+
 if 'macosx' in platform:
-    retag_wheel(wpath, 'macosx_11_0_universal2', replace=False)
-    retag_wheel(wpath, 'macosx_10_11_x86_64')
+    retag_wheel(wheelpath, 'macosx_11_0_universal2', replace=False)
+    retag_wheel(wheelpath, 'macosx_10_11_x86_64')
 elif platform in ['win32', 'win-amd64']:
-    retag_wheel(wpath, platform.replace('-', '_'))
+    retag_wheel(wheelpath, platform.replace('-', '_'))
 elif 'manylinux' in platform:
     arch = get_platform().split('-')[-1]
-    retag_wheel(wpath, '_'.join([platform, arch]))
+    retag_wheel(wheelpath, '_'.join([platform, arch]))
 else:
-    retag_wheel(wpath, 'any')
+    retag_wheel(wheelpath, 'any')

--- a/fix_wheels.py
+++ b/fix_wheels.py
@@ -87,7 +87,7 @@ if not wheelpath:
 tmpdir = tempfile.mkdtemp(prefix='pysdl2-dll-wheel')
 wheeldir = unpack_wheel(wheelpath, tmpdir)
 add_licenses(wheeldir)
-os.rename(wheelpath, wheelpath + '.bak')
+os.remove(wheelpath)
 repack_wheel(wheeldir, 'dist')
 
 

--- a/fix_wheels.py
+++ b/fix_wheels.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import subprocess as sub
 from sysconfig import get_platform
@@ -16,7 +17,7 @@ def find_wheel():
 
 
 def retag_wheel(path, platform, replace=True):
-    base_cmd = ['wheel', 'tags']
+    base_cmd = [sys.executable, '-m', 'wheel', 'tags']
     if replace:
         base_cmd += ['--remove']
     opts = [

--- a/fix_wheels.py
+++ b/fix_wheels.py
@@ -1,0 +1,44 @@
+import os
+import glob
+import subprocess as sub
+from sysconfig import get_platform
+
+override = os.getenv('SDL2DLL_PLATFORM')
+platform = get_platform() if not override else override
+
+
+def find_wheel():
+    if os.path.isdir('dist'):
+        wheels = glob.glob("dist/pysdl2_dll*.whl")
+        if len(wheels):
+            return wheels[0]
+    return None
+
+
+def retag_wheel(path, platform, replace=True):
+    base_cmd = ['wheel', 'tags']
+    if replace:
+        base_cmd += ['--remove']
+    opts = [
+        '--python-tag=py2.py3',
+        '--abi-tag=none',
+        '--platform-tag=' + platform
+    ]
+    cmd = base_cmd + opts + [path]
+    sub.run(cmd, check=True)
+
+
+wpath = find_wheel()
+if not wpath:
+    raise RuntimeError("No wheels found in dist!")
+
+if 'macosx' in platform:
+    retag_wheel(wpath, 'macosx_11_0_universal2', replace=False)
+    retag_wheel(wpath, 'macosx_10_11_x86_64')
+elif platform in ['win32', 'win-amd64']:
+    retag_wheel(wpath, platform.replace('-', '_'))
+elif 'manylinux' in platform:
+    arch = get_platform().split('-')[-1]
+    retag_wheel(wpath, '_'.join([platform, arch]))
+else:
+    retag_wheel(wpath, 'any')

--- a/getdlls.py
+++ b/getdlls.py
@@ -61,7 +61,7 @@ cmake_opts = {
 def getDLLs(platform_name, dlldir):
     
     licensedir = os.path.join('sdl_licenses')
-    for d in ['temp', 'build', licensedir]:
+    for d in ['temp', licensedir]:
         if os.path.isdir(d):
             shutil.rmtree(d)
         os.mkdir(d)

--- a/getdlls.py
+++ b/getdlls.py
@@ -60,18 +60,9 @@ cmake_opts = {
 
 def getDLLs(platform_name, dlldir):
     
-    licensedir = os.path.join('sdl_licenses')
-    for d in ['temp', licensedir]:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
-        os.mkdir(d)
-
-    # Generate license disclaimer for SDL2 libraries (all under zlib)
-    sdl_licensepath = os.path.join(licensedir, 'LICENSE.SDL2.txt')
-    with open(sdl_licensepath, 'w') as l:
-        l.write("SDL2 License Info\n---\n\n")
-        l.write("SDL2, SDL2_mixer, SDL2_ttf, SDL2_image, and SDL2_gfx are all distributed\n")
-        l.write("under the terms of the zlib license: http://www.zlib.net/zlib_license.html\n")
+    if os.path.isdir('temp'):
+        shutil.rmtree('temp')
+    os.mkdir('temp')
     
     if 'macosx' in platform_name:
         
@@ -99,25 +90,6 @@ def getDLLs(platform_name, dlldir):
                 )
             sub.call(['hdiutil', 'unmount', mountpoint])
 
-            # Extract license info from frameworks bundled within main framework
-            if os.path.exists(extraframeworkpath):
-                for f in os.listdir(extraframeworkpath):
-                    resourcepath = os.path.join(extraframeworkpath, f, 'Versions', 'A', 'Resources')
-                    if os.path.exists(resourcepath):
-                        for name in os.listdir(resourcepath):
-                            if 'LICENSE' in name:
-                                licensepath = os.path.join(resourcepath, name)
-                                outpath = os.path.join(licensedir, name)
-                                shutil.copyfile(licensepath, outpath)
-
-            # Extract license info for statically-linked libraries
-            resourcepath = os.path.join(dlloutpath, 'Versions', 'A', 'Resources')
-            for name in os.listdir(resourcepath):
-                if 'LICENSE' in name or name == "FTL.TXT":
-                    licensepath = os.path.join(resourcepath, name)
-                    outpath = os.path.join(licensedir, name)
-                    shutil.copyfile(licensepath, outpath)
-
     elif platform_name in ['win32', 'win-amd64']:
         
         suffix = '-win32-x64.zip' if platform_name == 'win-amd64' else '-win32-x86.zip'
@@ -130,20 +102,17 @@ def getDLLs(platform_name, dlldir):
             print(' * Downloading {0} {1}...'.format(lib, libversion))
             download(sdl2_urls[lib].format(libversion, suffix), outpath)
             
-            # Extract dlls and license files from archive
+            # Extract dlls from archive
             with ZipFile(outpath, 'r') as z:
                 for name in z.namelist():
                     if name[-4:] == '.dll':
                         z.extract(name, dlldir)
-                    elif 'LICENSE' in name:
-                        z.extract(name, licensedir)
 
-            # Move any optional dlls and licenses into their respective root folders
-            for d in [dlldir, licensedir]:
-                optdir = os.path.join(d, 'optional')
-                if os.path.isdir(optdir):
-                    for f in os.listdir(optdir):
-                        shutil.move(os.path.join(optdir, f), os.path.join(d, f))
+            # Move any optional dlls into the root folder
+            optdir = os.path.join(dlldir, 'optional')
+            if os.path.isdir(optdir):
+                for f in os.listdir(optdir):
+                    shutil.move(os.path.join(optdir, f), os.path.join(dlldir, f))
 
     elif 'manylinux' in platform_name or os.getenv('SDL2DLL_UNIX_COMPILE', '0') == '1':
 
@@ -153,25 +122,6 @@ def getDLLs(platform_name, dlldir):
         if os.path.isdir(libdir):
             shutil.rmtree(libdir)
         os.mkdir(libdir)
-
-        # Download and use license files from official Windows binaries
-        for lib in libraries:
-            # Download zip archive containing library
-            libversion = libversions[lib]
-            outpath = os.path.join('temp', lib + '.zip')
-            download(sdl2_urls[lib].format(libversion, '-win32-x64.zip'), outpath)
-
-            # Extract license files from archive
-            with ZipFile(outpath, 'r') as z:
-                for name in z.namelist():
-                    if 'LICENSE' in name:
-                        z.extract(name, licensedir)
-
-            # Move any optional licenses into the root license folder
-            optdir = os.path.join(licensedir, 'optional')
-            if os.path.isdir(optdir):
-                for f in os.listdir(optdir):
-                    shutil.move(os.path.join(optdir, f), os.path.join(licensedir, f))
 
         # Build and install everything into the custom prefix
         sdl2_urls['SDL2_gfx'] = 'http://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-{0}{1}'

--- a/getdlls.py
+++ b/getdlls.py
@@ -246,7 +246,7 @@ def buildDLLs(libraries, basedir, libdir):
         # Fetch updated config.guess/config.sub scripts (needed for gfx on non-x86)
         cfgfiles = {}
         cfgnames = ['config.guess', 'config.sub']
-        cfgurl = 'https://git.savannah.gnu.org/cgit/config.git/plain/{0}'
+        cfgurl = 'https://cgit.git.savannah.gnu.org/cgit/config.git/plain/{0}'
         for name in cfgnames:
             cfgfiles[name] = urlopen(cfgurl.format(name)).read()
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -172,9 +172,6 @@ def getDLLs(platform_name, dlldir):
         with open(dummyfile, 'w') as f:
             f.write("No dlls available for this platform!")
 
-        # Remove unneeded license file
-        os.remove(sdl_licensepath)
-
     shutil.rmtree('temp')
 
 

--- a/getdlls.py
+++ b/getdlls.py
@@ -88,6 +88,7 @@ def getDLLs(platform_name):
             # Download disk image containing library
             outpath = os.path.join('temp', lib + '.dmg')
             libversion = libversions[lib]
+            print('\n * Downloading {0} {1}...\n'.format(lib, libversion))
             download(sdl2_urls[lib].format(libversion, '.dmg'), outpath)
             
             # Mount image, extract framework (and any optional frameworks), then unmount
@@ -127,6 +128,7 @@ def getDLLs(platform_name):
             # Download zip archive containing library
             libversion = libversions[lib]
             outpath = os.path.join('temp', lib + '.zip')
+            print(' * Downloading {0} {1}...'.format(lib, libversion))
             download(sdl2_urls[lib].format(libversion, suffix), outpath)
             
             # Extract dlls and license files from archive

--- a/getdlls.py
+++ b/getdlls.py
@@ -58,11 +58,10 @@ cmake_opts = {
 }
 
 
-def getDLLs(platform_name):
+def getDLLs(platform_name, dlldir):
     
-    dlldir = os.path.join('sdl2dll', 'dll')
     licensedir = os.path.join('sdl_licenses')
-    for d in ['temp', 'build', dlldir, licensedir]:
+    for d in ['temp', 'build', licensedir]:
         if os.path.isdir(d):
             shutil.rmtree(d)
         os.mkdir(d)

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -118,8 +118,8 @@ fi
 
 # Compile SDL2, addon libraries, and any necessary dependencies
 
-python3.10 -m pip install build
-python3.10 -u -m build
+python3.10 -m pip install -U setuptools wheel build
+python3.10 -u -m build -w
 python3.10 fix_wheels.py
 
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -120,6 +120,7 @@ fi
 
 python3.10 -m pip install build
 python3.10 -u -m build
+python3.10 fix_wheels.py
 
 
 # Run unit tests on built pysdl2-dll wheel

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -119,7 +119,7 @@ fi
 # Compile SDL2, addon libraries, and any necessary dependencies
 
 python3.10 -m pip install -U setuptools wheel build
-python3.10 -u -m build -w
+python3.10 -u -m build -w -vv
 python3.10 fix_wheels.py
 
 

--- a/manylinux.sh
+++ b/manylinux.sh
@@ -118,8 +118,8 @@ fi
 
 # Compile SDL2, addon libraries, and any necessary dependencies
 
-#python3.10 -m pip install requests
-python3.10 -u setup.py bdist_wheel
+python3.10 -m pip install build
+python3.10 -u -m build
 
 
 # Run unit tests on built pysdl2-dll wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pysdl2-dll"
+version = "2.32.6"
+description = "Pre-built SDL2 binaries for PySDL2"
+readme = "README.md"
+license = "MPL-2.0"
+requires-python = ">=2.7"
+authors = [
+    { name = "Austin Hurst", email = "mynameisaustinhurst@gmail.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries",
+]
+
+[project.urls]
+Homepage = "https://github.com/a-hurst/pysdl2-dll"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[metadata]
-license_files = 
-    LICENSE
-    sdl_licenses/*.txt
-    sdl_licenses/*.TXT

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
 	version='2.32.6',
 	author='Austin Hurst',
 	author_email='mynameisaustinhurst@gmail.com',
-    license='Mozilla Public License Version 2.0',
+    license='MPL-2.0',
     description='Pre-built SDL2 binaries for PySDL2',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,13 @@
-#!/usr/bin/env python
-
 import os
-from setuptools import setup
-from distutils.util import get_platform
-try:
-    from setuptools.command.build import build as BuildCommand
-except ImportError:
-    from distutils.command.build import build as BuildCommand
+import sys
+from pathlib import Path
+from contextlib import suppress
+from sysconfig import get_platform
+from setuptools import Command, setup
+from setuptools.command.build import build
 
+sys.path.append(".")
 from getdlls import getDLLs
-
-
-dllfiles = []
-cmdclass = {}
 
 override = os.getenv('SDL2DLL_PLATFORM')
 platform = get_platform() if not override else override
@@ -20,82 +15,36 @@ platform = get_platform() if not override else override
 
 # Define custom build method that gathers platform-specific SDL binaries
 
-class CustomBuild(BuildCommand):
+class CustomCommand(Command):
+
+    def initialize_options(self):
+        self.bdist_dir = None
+        self.get_dlls = False
+
+    def finalize_options(self):
+        with suppress(Exception):
+            self.bdist_dir = Path(self.get_finalized_command("bdist_wheel").bdist_dir)
+            self.get_dlls = True if self.bdist_dir else False
 
     def run(self):
+        if self.get_dlls:
+            # Create the bdist and binary output paths
+            self.bdist_dir.mkdir(parents=True, exist_ok=True)
+            dllpath = os.path.join(self.bdist_dir, 'sdl2dll', 'dll')
+            os.makedirs(dllpath)
 
-        # Get the necessary SDL2 DLLs for the platform
-        getDLLs(platform)
-
-        # Gather list of dlls so that they can be included in wheels but not sdists
-        dllpath = os.path.join('sdl2dll', 'dll')
-        for path, _, files in os.walk(dllpath):
-            for f in files:
-                parentdir = 'sdl2dll' + os.sep
-                filepath = os.path.join(path, f).replace(parentdir, '')
-                dllfiles.append(filepath)
-
-        BuildCommand.run(self)
-
-cmdclass['build'] = CustomBuild
+            # Get or build the necessary SDL2 DLLs for the platform
+            getDLLs(platform, dllpath)
 
 
-# Patch wheel naming to be platform-specific but Python version/ABI independent
-
-try:
-    from wheel.bdist_wheel import bdist_wheel
-
-    class bdist_wheel_half_pure(bdist_wheel):
-
-        def get_tag(self):
-            if 'macosx' in platform:
-                system = 'macosx_10_11_universal2'
-                if os.getenv('MACOS_LEGACY_WHEEL'):
-                    system = 'macosx_10_11_x86_64'
-            elif platform in ['win32', 'win-amd64']:
-                system = platform.replace('-', '_')
-            elif 'manylinux' in platform:
-                arch = get_platform().split('-')[-1]
-                system = '_'.join([platform, arch])
-            else:
-                system = 'any'
-            return 'py2.py3', 'none', system
-
-    cmdclass['bdist_wheel'] = bdist_wheel_half_pure
-
-except ImportError:
-    pass
+class CustomBuild(build):
+    sub_commands = [('build_custom', None)] + build.sub_commands
 
 
 # Install the package
 
-with open('README.md', 'r') as f:
-    long_description = f.read()
-
 setup(
-	name='pysdl2-dll',
-	version='2.32.6',
-	author='Austin Hurst',
-	author_email='mynameisaustinhurst@gmail.com',
-    license='MPL-2.0',
-    description='Pre-built SDL2 binaries for PySDL2',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/a-hurst/pysdl2-dll',
 	packages=['sdl2dll'],
-	cmdclass=cmdclass,
-    package_data={'sdl2dll': dllfiles},
-	include_package_data=True,
-	install_requires=[],
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-        'Operating System :: MacOS',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries'
-    ]
+	cmdclass={'build': CustomBuild, 'build_custom': CustomCommand},
+    include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -3,31 +3,44 @@
 import os
 from setuptools import setup
 from distutils.util import get_platform
+try:
+    from setuptools.command.build import build as BuildCommand
+except ImportError:
+    from distutils.command.build import build as BuildCommand
 
 from getdlls import getDLLs
 
 
-# Get the necessary SDL2 DLLs for the platform
+dllfiles = []
+cmdclass = {}
 
 override = os.getenv('SDL2DLL_PLATFORM')
 platform = get_platform() if not override else override
-getDLLs(platform)
 
 
-# Gather list of all dll files so that they can be included in wheels, but not sdist
+# Define custom build method that gathers platform-specific SDL binaries
 
-dllpath = os.path.join('sdl2dll', 'dll')
-dllfiles = []
-for path, _, files in os.walk(dllpath):
-    for f in files:
-        parentdir = 'sdl2dll' + os.sep
-        filepath = os.path.join(path, f).replace(parentdir, '')
-        dllfiles.append(filepath)
+class CustomBuild(BuildCommand):
+
+    def run(self):
+
+        # Get the necessary SDL2 DLLs for the platform
+        getDLLs(platform)
+
+        # Gather list of dlls so that they can be included in wheels but not sdists
+        dllpath = os.path.join('sdl2dll', 'dll')
+        for path, _, files in os.walk(dllpath):
+            for f in files:
+                parentdir = 'sdl2dll' + os.sep
+                filepath = os.path.join(path, f).replace(parentdir, '')
+                dllfiles.append(filepath)
+
+        BuildCommand.run(self)
+
+cmdclass['build'] = CustomBuild
 
 
 # Patch wheel naming to be platform-specific but Python version/ABI independent
-
-cmdclass = {}
 
 try:
     from wheel.bdist_wheel import bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 from pathlib import Path
 from contextlib import suppress
 from sysconfig import get_platform
@@ -34,7 +35,11 @@ class CustomCommand(Command):
             os.makedirs(dllpath)
 
             # Get or build the necessary SDL2 DLLs for the platform
-            getDLLs(platform, dllpath)
+            try:
+                getDLLs(platform, dllpath)
+            except Exception as e:
+                print(traceback.format_exc())
+                raise e
 
 
 class CustomBuild(build):


### PR DESCRIPTION
This PR migrates the project to a `pyproject.toml` file and rewrites the wheel build and bundling process to be less hacky and align better with modern setuptools.

Main changes include:
- Migrated to the `build` package for building sdists and wheels since `python setup.py bdist_wheel` is now deprecated.
- Migrated package info to `pyproject.toml` and rewrote `setup.py` to be much simpler (and work with the `build` package), using a less hacky more future-proof solution for adding custom build steps into the process.
- Moved custom wheel tagging (Python/ABI agnostic, platform-specific) from setup.py to a separate post-build script using the official `wheel tags` utility.
- Fixed and rewrote license handling based on PEP 639, using a custom script to insert the SDL2 + dependency library license files into the wheel (and update the METADATA file accordingly) post-build instead of trying downloading them in the main script and trying to get setuptools to find/include them.

Closes #13.