### PR TITLE
Bump SDL to 2.32.10 and mixer/image to the latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # pysdl2-dll changelog
 
-### Version 2.32.6 (Unreleased)
+### Version 2.32.10 (Unreleased)
 
-- Bumped the SDL2 binary version from 2.32.0 to 2.32.6.
-- Bumped the SDL2\_image binary version from 2.8.6 to 2.8.8.
+- Bumped the SDL2 binary version from 2.32.0 to 2.32.10.
+- Bumped the SDL2\_image binary version from 2.8.6 to 2.8.12.
+- Bumped the SDL2\_mixer binary version from 2.8.1 to 2.8.2.
+- Fixed wheel compatibility with Python 2.7 on macOS ARM.
+- Rewrote the build system to align better with modern setuptools.
 
 
 ### Version 2.32.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest release includes the following versions of the SDL2 binaries:
 
 SDL2 | SDL2\_ttf | SDL2\_mixer | SDL2\_image | SDL2\_gfx
 --- | --- | --- | --- | ---
-2.32.6 | 2.24.0 | 2.8.1 | 2.8.8 | 1.0.4
+2.32.10 | 2.24.0 | 2.8.2 | 2.8.12 | 1.0.4
 
 
 ## Installation

--- a/getdlls.py
+++ b/getdlls.py
@@ -17,10 +17,10 @@ except ImportError:
 libraries = ['SDL2', 'SDL2_mixer', 'SDL2_ttf', 'SDL2_image', 'SDL2_gfx']
 
 libversions = {
-    'SDL2': '2.32.6',
-    'SDL2_mixer': '2.8.1',
+    'SDL2': '2.32.10',
+    'SDL2_mixer': '2.8.2',
     'SDL2_ttf': '2.24.0',
-    'SDL2_image': '2.8.8',
+    'SDL2_image': '2.8.12',
     'SDL2_gfx': '1.0.4'
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysdl2-dll"
-version = "2.32.6"
+version = "2.32.10"
 description = "Pre-built SDL2 binaries for PySDL2"
 readme = "README.md"
 license = "MPL-2.0"

--- a/sdl2dll/__init__.py
+++ b/sdl2dll/__init__.py
@@ -1,6 +1,6 @@
 """Adds the SDL2 DLLs in the package to the PySDL2 DLL search path"""
 
-__version__ = "2.32.6"
+__version__ = "2.32.10"
 
 import os
 from .initcheck import is_sdist, init_check


### PR DESCRIPTION
Updates SDL2 and its add-on binaries to their latest bugfix releases!